### PR TITLE
Script enhancements

### DIFF
--- a/qvi-workflow/docker-compose-qvi-workflow-kli.yaml
+++ b/qvi-workflow/docker-compose-qvi-workflow-kli.yaml
@@ -8,11 +8,11 @@
 # x-keri12-image: &keri12-image
 #     image: kentbull/keri:1.2.1a    
 x-witness-demo-image: &witness-demo-image
-    image: kentbull/keri-witness-demo:1.1.27a   
+    image: weboftrust/keri:1.1.30
 x-keria-image: &keria-image
-    image: weboftrust/keria:0.2.0-dev6
+    image: weboftrust/keria:0.2.0-rc2
 x-vlei-image: &vlei-image
-    image: kentbull/vlei:0.2.2
+    image: gleif/vlei:0.2.0
 
 x-healthcheck: &healthcheck
     interval: 15s
@@ -26,18 +26,21 @@ networks:
     name: vlei
 
 services:
-
+  # vLEI schema caching server
   vlei-server:
     <<: *vlei-image
     environment:
         - PYTHONUNBUFFERED=1     # Ensure output is logged in real-time
         - PYTHONIOENCODING=UTF-8 # Ensure consistent logging encoding
+    command:
+      [ 'vLEI-server', '-s','./schema/acdc','-c','./schema/acdc','-o','./samples/oobis' ]
     healthcheck:
         test: ["CMD", "curl", "-f", "http://127.0.0.1:7723/oobi/EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao"]
         <<: *healthcheck
     ports:
         - "7723:7723"   
 
+  # Six demo witnesses
   witness-demo:
     <<: *witness-demo-image
     environment:
@@ -47,15 +50,16 @@ services:
     healthcheck:
       test: curl -f http://127.0.0.1:5642/oobi
       <<: *healthcheck
+    command: witness demo
     volumes:
       - ./config/witness-demo-docker:/keripy/scripts/keri/cf/main
     ports:
-      - "5642:5642"
-      - "5643:5643"
-      - "5644:5644"
-      - "5645:5645"
-      - "5646:5646"
-      - "5647:5647"
+      - "5642:5642" # witness named wan
+      - "5643:5643" # witness named wil
+      - "5644:5644" # witness named wes
+      - "5645:5645" # witness named wit
+      - "5646:5646" # witness named wub
+      - "5647:5647" # witness named wyz
     depends_on:
       vlei-server:
         condition: service_healthy   
@@ -68,7 +72,7 @@ services:
       - PYTHONIOENCODING=UTF-8 # Ensure consistent logging encoding
     volumes:
       - ./config/keria/keria.json:/keria/config/keri/cf/keria.json
-    command: --config-dir /keria/config --config-file keria --name agent
+    command: --config-dir /keria/config --config-file keria --name agent --loglevel INFO
     healthcheck:
       test: ["CMD", "wget", "--spider", "--tries=1", "--no-verbose", "http://127.0.0.1:3902/spec.yaml"]
       <<: *healthcheck
@@ -77,7 +81,7 @@ services:
       - "3902:3902"
       - "3903:3903"
     entrypoint:
-      ['keria', 'start','--config-dir','/keria/config','--config-file','keria','--name','agent',]
+      ['keria', 'start','--config-dir','/keria/config','--config-file','keria','--name','agent', '--loglevel', 'INFO']
     depends_on:
       vlei-server:
         condition: service_healthy

--- a/qvi-workflow/kli-commands.sh
+++ b/qvi-workflow/kli-commands.sh
@@ -14,13 +14,14 @@ if [ ! -d "${KEYSTORE_DIR}" ]; then
 fi
 
 # Set current working directory for all scripts that must access files
-KLI1IMAGE="weboftrust/keri:1.1.29"
-KLI2IMAGE="weboftrust/keri:1.2.2"
+KLI1IMAGE="weboftrust/keri:1.1.30"
+KLI2IMAGE="weboftrust/keri:1.2.4"
 
 LOCAL_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 export KLI_DATA_DIR="${LOCAL_DIR}/data"
 export KLI_CONFIG_DIR="${LOCAL_DIR}/config"
 
+# Separate function enables different version of KERIpy to be used for some identifiers.
 function kli() {
   docker run -it --rm \
     --network vlei \
@@ -33,12 +34,13 @@ function kli() {
 
 export -f kli
 
+# Runs the KLI command in a detached container which is expected to be used in conjunction with
+# `docker wait` to wait for the container to finish before continuing with further steps.
 function klid() {
   name=$1
   # must pull first arg off to use as container name
   shift 1
   # pass remaining args to docker run
-  set -xe
   docker run -d \
     --network vlei \
     --name $name \
@@ -46,12 +48,12 @@ function klid() {
     -v "${KLI_CONFIG_DIR}:/config" \
     -v "${KLI_DATA_DIR}":/data \
     -e PYTHONWARNINGS="ignore::SyntaxWarning" \
-    "${KLI1IMAGE}" "$@" 
-  set +xe
+    "${KLI1IMAGE}" "$@"
 }
 
 export -f klid
 
+# Separate function enables different version of KERIpy to be used for some identifiers.
 function kli2() {
   docker run -it --rm \
     --network vlei \
@@ -64,12 +66,13 @@ function kli2() {
 
 export -f kli2
 
+# Runs the KLI command in a detached container which is expected to be used in conjunction with
+# `docker wait` to wait for the container to finish before continuing with further steps.
 function kli2d() {
   name=$1
   # must pull first arg off to use as container name
   shift 1
   # pass remaining args to docker run
-  set -xe
   docker run -d \
     --network vlei \
     --name $name \
@@ -78,7 +81,6 @@ function kli2d() {
     -v "${KLI_DATA_DIR}":/data \
     -e PYTHONWARNINGS="ignore::SyntaxWarning" \
     "${KLI2IMAGE}" "$@"
-  set +xe
 }
 
 export -f kli2d

--- a/qvi-workflow/package-lock.json
+++ b/qvi-workflow/package-lock.json
@@ -15,9 +15,9 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-            "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+            "version": "7.26.7",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.7.tgz",
+            "integrity": "sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==",
             "license": "MIT",
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
@@ -476,9 +476,9 @@
             }
         },
         "node_modules/@noble/hashes": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.0.tgz",
-            "integrity": "sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==",
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+            "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
             "license": "MIT",
             "engines": {
                 "node": "^14.21.3 || >=16"
@@ -641,9 +641,9 @@
             "license": "MIT"
         },
         "node_modules/decimal.js": {
-            "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-            "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
+            "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
             "license": "MIT"
         },
         "node_modules/diff": {
@@ -866,8 +866,7 @@
         },
         "node_modules/signify-ts": {
             "version": "0.3.0-rc1",
-            "resolved": "https://registry.npmjs.org/signify-ts/-/signify-ts-0.3.0-rc1.tgz",
-            "integrity": "sha512-mCEt+Dn2l8fzFLePYd+MuBnbht9NhUj3B5NE9NYRhxtFpP+0E/78E8fb6rDwMC9qsRrI9/HX4Jpayt8juR4M2Q==",
+            "resolved": "file:../../../keri/kentbull/signify-ts",
             "license": "Apache-2.0",
             "workspaces": [
                 "examples/*"

--- a/qvi-workflow/qvi-workflow-kli-docker.sh
+++ b/qvi-workflow/qvi-workflow-kli-docker.sh
@@ -5,8 +5,10 @@
 # Person AID for usage in the iXBRL data attestation.
 #
 # Note:
-# This script uses the kli and kli2 commands as defined in ./kli-commands.sh to perform the QVI
-# workflow steps.
+# 1) This script uses the kli and kli2 commands as defined in ./kli-commands.sh to perform the QVI
+#    workflow steps.
+# 2) $HOME/.qvi_workflow_docker should be cleared out prior to running this script.
+#    By specifying a directory as the first argument to this script you can control where the keystores are located.
 #
 
 

--- a/readme.md
+++ b/readme.md
@@ -3,10 +3,10 @@
 ## GLEIF tested versions for technical dry runs
 
 * GLEIF (KERIpy 1.1.30) (https://github.com/WebOfTrust/keripy/releases/tag/1.1.30)
-* GLEIF witnesses (KERIpy 1.2.3) (https://github.com/WebOfTrust/keripy/releases/tag/1.2.3)
-* QVI (KERIA 0.2.0-rc1) (https://github.com/GLEIF-IT/keria/releases/tag/0.2.0-rc1)
+* GLEIF witnesses (KERIpy 1.2.4) (https://github.com/WebOfTrust/keripy/releases/tag/1.2.4)
+* QVI (KERIA 0.2.0-rc2) (https://github.com/GLEIF-IT/keria/releases/tag/0.2.0-rc1)
 * QVI (SignifyTS 0.3.0-rc1) (https://github.com/GLEIF-IT/signify-ts/releases/tag/0.3.0-rc1)
-* QVI witnesses (KERIpy 1.2.3) (https://github.com/WebOfTrust/keripy/releases/tag/1.2.3)
+* QVI witnesses (KERIpy 1.2.4) (https://github.com/WebOfTrust/keripy/releases/tag/1.2.4)
 
 #### Table of functionality
 

--- a/tested-stacks/running-tests.md
+++ b/tested-stacks/running-tests.md
@@ -2,10 +2,10 @@
 
 Stack A:
 - Compose file: `stack_A-docker-compose.yaml`
-- KERIpy 1.1.27
-- KERIA 0.2.0-dev6
-- vLEI-server 0.2.1
-- SignifyTS 0.3.0
+- KERIpy 1.1.30
+- KERIA 0.2.0-rc2
+- vLEI-server 0.2.2
+- SignifyTS 0.3.0-rc1
 
 # Important Points
 

--- a/tested-stacks/stack_A-docker-compose.yaml
+++ b/tested-stacks/stack_A-docker-compose.yaml
@@ -2,11 +2,11 @@
 # Starts up five witnesses, a KERIA agent server, and an ACDC schema caching server (vLEI-server)
 
 x-keri-image: &keri-image
-    image: weboftrust/keri:1.1.27
+    image: weboftrust/keri:1.1.30
 x-keria-image: &keria-image
-    image: weboftrust/keria:0.2.0-dev6
+    image: weboftrust/keria:0.2.0-rc2
 x-vlei-image: &vlei-image
-    image: gleif/vlei:0.2.1
+    image: gleif/vlei:0.2.0
 
 # Healthcheck interval for all services
 x-healthcheck: &healthcheck
@@ -28,6 +28,20 @@ volumes:
     keria-data:
 
 services:
+    # Start vLEI server for caching credential schema
+    vlei-server:
+        <<: *vlei-image
+        environment:
+            - PYTHONUNBUFFERED=1     # Ensure output is logged in real-time
+            - PYTHONIOENCODING=UTF-8 # Ensure consistent logging encoding
+        command:
+          [ 'vLEI-server', '-s','./schema/acdc','-c','./schema/acdc','-o','./samples/oobis' ]
+        healthcheck:
+            test: [ "CMD", "curl", "-f", "http://127.0.0.1:7723/oobi/EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao" ]
+            <<: *healthcheck
+        ports:
+            - "7723:7723"
+
     # Starts five witnesses, epsilon, kappa, phi, sigma, and zeta
     wit-eps:
         <<: *keri-image
@@ -54,6 +68,9 @@ services:
             - /witness-entrypoint.sh
         ports:
             - "5642:5642"
+        depends_on:
+            vlei-server:
+                condition: service_healthy
 
     wit-kap:
         <<: *keri-image
@@ -80,6 +97,9 @@ services:
             - /witness-entrypoint.sh
         ports:
             - "5643:5643"
+        depends_on:
+            vlei-server:
+                condition: service_healthy
 
     wit-phi:
         <<: *keri-image
@@ -106,6 +126,9 @@ services:
             - /witness-entrypoint.sh
         ports:
             - "5644:5644"
+        depends_on:
+            vlei-server:
+                condition: service_healthy
 
     wit-sig:
         <<: *keri-image
@@ -132,6 +155,9 @@ services:
             - /witness-entrypoint.sh
         ports:
             - "5645:5645"
+        depends_on:
+            vlei-server:
+                condition: service_healthy
 
     wit-zet:
         <<: *keri-image
@@ -158,17 +184,9 @@ services:
             - /witness-entrypoint.sh
         ports:
             - "5646:5646"
-
-    vlei-server:
-        <<: *vlei-image
-        environment:
-            - PYTHONUNBUFFERED=1     # Ensure output is logged in real-time
-            - PYTHONIOENCODING=UTF-8 # Ensure consistent logging encoding
-        healthcheck:
-            test: ["CMD", "curl", "-f", "http://127.0.0.1:7723/oobi/EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao"]
-            <<: *healthcheck
-        ports:
-            - "7723:7723"
+        depends_on:
+            vlei-server:
+                condition: service_healthy
 
     keria:
         <<: *keria-image
@@ -179,7 +197,7 @@ services:
         volumes:
             - ./config-keria/keria.json:/keria/config/keri/cf/keria.json
             - keria-data:/keria/config/keri/cf
-        command: --config-dir /keria/config --config-file keria --name agent
+        command: --config-dir /keria/config --config-file keria --name agent --loglevel INFO
         healthcheck:
             test: ["CMD", "wget", "--spider", "--tries=1", "--no-verbose", "http://127.0.0.1:3902/spec.yaml"]
             <<: *healthcheck
@@ -188,8 +206,10 @@ services:
             - "3902:3902"
             - "3903:3903"
         entrypoint:
-          ['keria', 'start','--config-dir','/keria/config','--config-file','keria','--name','agent',]
+          ['keria', 'start','--config-dir','/keria/config','--config-file','keria','--name','agent', '--loglevel', 'INFO']
         depends_on:
+            vlei-server:
+                condition: service_healthy
             wit-eps:
                 condition: service_healthy
             wit-kap:
@@ -199,7 +219,5 @@ services:
             wit-sig:
                 condition: service_healthy
             wit-zet:
-                condition: service_healthy
-            vlei-server:
                 condition: service_healthy
 


### PR DESCRIPTION
Changes images to
- weboftrust/keri:1.1.30
- weboftrust/keria:0.2.0-rc2
- gleif/vlei:0.2.0

Adds old gleif/vlei image command to go along with that image.

Adds the `--loglevel INFO` arg to KERIA startup so that logging output shows rather than a blank output.

Cleans up the tested stacks and the integration test stack for `qvi-workflow-kli-docker.sh` script.

Adds a simple polling check to Sally to determine whether a presentation is in the local cache of received presentations.