### PR TITLE
Parallelize the canonical KERIA Docker workflow

### DIFF
--- a/qvi-workflow/keria_docker/BENCHMARK.md
+++ b/qvi-workflow/keria_docker/BENCHMARK.md
@@ -1,0 +1,60 @@
+# KERIA Docker workflow benchmark
+
+## Method
+
+The serial baseline is merged PR 56 at `04e1659`, with the PR 55 challenge
+matrix restored to all eight relationships and 16 directed exchanges. Each
+sample started after a clean Compose teardown and used the same fixture data,
+image cache, timeout, and Docker allocation.
+
+The optimized workflow retains the complete challenge, delegated rotation,
+credential, reporting, and revocation assertions. Its first clean full proof
+completed in 606 seconds. A subsequent focused run through final QVI
+convergence measured the hardened query and member-sync lanes without paying
+for the unchanged credential tail.
+
+Measurements were taken on:
+
+- MacBook Pro `MacBookPro18,2`;
+- Apple M1 Max, 10 cores and 64 GB host memory;
+- Docker Engine 29.6.2 with 8 CPUs and 10,418,937,856 bytes of memory.
+
+## Results
+
+| Variant | Clean wall-clock samples | Median or result |
+| --- | --- | --- |
+| Serial `04e1659` plus full challenge matrix | 827.56 s, 830 s, 828 s | 828 s median |
+| First clean optimized full workflow | 606 s | 606 s |
+| Hardened optimized setup through final QVI convergence | 307 s | 307 s |
+
+The first complete optimized proof reduced wall time by 222 seconds, or
+26.8%, against the serial median. The hardened QVI-focused run reduced the
+same setup-plus-delegation section from 381 seconds to 307 seconds, a further
+74-second or 19.4% reduction on that critical path.
+
+The focused timing file reports 35 seconds for setup and 272 seconds for the
+complete GEDA/QVI phase. Remaining slow operations are protocol or transport
+waits rather than hidden shell sleeps:
+
+- per-GAR QAR state-query lanes: up to 24 seconds;
+- Signify member synchronization: 6–8 seconds;
+- delegator refresh: 5–9 seconds;
+- QVI endpoint authorization: 11 seconds.
+
+## Behavioral evidence
+
+The clean full optimized run proved:
+
+- all 16 directed challenge exchanges;
+- delegated QVI convergence at sequences 0–3 with final QAR1/QAR2/QAR4
+  membership;
+- all six credentials issued and admitted;
+- active QVI, LE, and OOR callbacks;
+- OOR and ECR convergence at TEL sequence `1`;
+- Person observation of the revoked OOR;
+- exact Sally rejection of the revoked OOR and the matching `rev` callback;
+- clean teardown.
+
+The later QVI-focused run re-proved the complete challenge matrix and QVI
+sequences 0–3 after parallelizing only actor-disjoint GAR query lanes and
+Signify observer lanes.

--- a/qvi-workflow/keria_docker/README.md
+++ b/qvi-workflow/keria_docker/README.md
@@ -80,28 +80,36 @@ The next invocation clears the retained stack and runtime automatically.
     --timeout SECONDS Timeout for each bounded operation (default: 120)
     --keep-runtime    Preserve runtime/ and the Compose stack
     --pause           Pause at story checkpoints
+    --stop-after NAME Stop after a named canonical phase
 -h, --help            Display help
 ```
 
 ## Story sequence
 
-1. Sally starts its own Habery and identifier through `sally server start`.
-2. GAR, LAR, QAR, and Person identifiers are created and exchange OOBIs.
+1. GAR, LAR, QAR, and Person identifiers are created. Independent wallet
+   setup and KLI inception jobs overlap.
+2. GEDA and LE inception run concurrently after each member pair has resolved
+   the other member's OOBI. Their registries, QAR resolution, and direct Sally
+   bootstrap then overlap where their actor sets are disjoint.
 3. The driver performs both directions of eight useful challenge
    relationships: GAR1-GAR2, LAR1-LAR2, the three QAR pairs, GAR1-QAR1,
    QAR1-LAR1, and QAR1-Person. All 16 response-and-verification commands must
    succeed.
-4. The GARs create the GEDA. The three QARs create the delegated QVI and
-   authorize its three KERIA agent endpoints.
+4. The three QARs create the delegated QVI. Its rotations remain deliberately
+   serial: sequences 1 and 2 prepare the replacement roster, then QAR4 joins
+   QAR1 and QAR2 at sequence 3. GEDA approval, refresh, and convergence are
+   required at each step.
 5. The workflow issues and admits the QVI and LE credentials, then presents
    both to Sally.
-6. The LE issues OOR-Auth; the QVI issues OOR to the Person. The Person admits
-   and presents the active OOR.
-7. The QVI revokes the OOR. All three QARs must observe status sequence `1`
-   and the same TEL digest. Sally must log the rejected revoked credential and
-   send the matching `rev` callback.
-8. The LE issues ECR-Auth; the QVI issues ECR to the Person. The Person admits
-   it, then all three QARs converge on the ECR revocation.
+6. The LE and QVI credential lanes overlap only when they mutate disjoint
+   AIDs, groups, registries, holders, and Sally state. Issuance and IPEX grant
+   are explicit separate operations.
+7. The Person admits and presents the active OOR while the QVI issues, but
+   does not yet grant, ECR.
+8. The QVI revokes OOR while the Person admits ECR. The Person then proves
+   Sally's revoked-OOR rejection and matching `rev` callback while the QVI
+   revokes ECR. All QARs must observe status sequence `1` and the same TEL
+   digest for both leaves.
 
 Sally 1.0.2 does not support the ECR reporting story, so this workflow does not
 present ECR. It simply ends that branch after admission and converged
@@ -138,16 +146,26 @@ With `--keep-runtime`, the generated files are deliberately easy to find:
 runtime/
 ├── acdc-info/
 ├── config/
-├── jobs/
 ├── keystores/
 ├── logs/
 ├── qvi_data/
-└── sally-callbacks.jsonl
+├── results/
+├── sally-callbacks.jsonl
+└── workflow-timings.jsonl
 ```
 
 The callback recorder accepts a JSON object at `POST /`, adds a receipt
 timestamp, and appends it to `sally-callbacks.jsonl`. See
 [`callback_recorder/README.md`](callback_recorder/README.md).
+Every named phase and background job also appends a JSON timing result to
+`workflow-timings.jsonl`; the driver prints the longest work first on exit.
+Each background job has dedicated stdout/stderr logs and an explicit JSON
+result under `runtime/results/`. Signify and KLI commands are timed as well,
+which makes the remaining protocol and transport waits visible without
+changing their deadlines.
+
+See [`BENCHMARK.md`](BENCHMARK.md) for the clean serial baseline, optimized
+measurements, machine allocation, and acceptance evidence.
 
 ## Developer checks
 
@@ -159,9 +177,11 @@ npm run typecheck
 npm test
 
 cd ../keria_docker
+./tests/workflow-contract-test.sh
 python3 -m unittest discover -s callback_recorder/tests -v
 docker compose \
   --env-file keria-signify-docker.env \
   -f docker-compose-keria_signify_qvi.yaml \
   config --quiet
+./vlei-workflow.sh --timeout 300 --keep-runtime
 ```

--- a/qvi-workflow/keria_docker/docker-compose-keria_signify_qvi.yaml
+++ b/qvi-workflow/keria_docker/docker-compose-keria_signify_qvi.yaml
@@ -248,11 +248,14 @@ services:
       vlei-server:
         condition: service_healthy
 
-  # Compose-scoped one-shot services used by the workflow driver.
+  # Persistent command runners used through `docker compose exec`.
   kli:
     <<: *keri_1_1-image
-    profiles: [ "jobs" ]
-    entrypoint: kli
+    entrypoint: [ "/bin/sh", "-c" ]
+    command:
+      - >-
+        trap 'exit 0' TERM INT;
+        while :; do sleep 3600 & wait $$!; done
     environment:
       PYTHONWARNINGS: ignore::SyntaxWarning
     volumes:
@@ -265,8 +268,11 @@ services:
     build:
       context: ../sig_ts_wallets
       dockerfile: signify-ts.Dockerfile
-    profiles: [ "jobs" ]
-    entrypoint: tsx
+    entrypoint: [ "/bin/sh", "-c" ]
+    command:
+      - >-
+        trap 'exit 0' TERM INT;
+        while :; do sleep 3600 & wait $$!; done
     environment:
       QVI_OPERATION_TIMEOUT_SECONDS: ${WORKFLOW_TIMEOUT_SECONDS:-120}
     volumes:

--- a/qvi-workflow/keria_docker/kli-commands.sh
+++ b/qvi-workflow/keria_docker/kli-commands.sh
@@ -3,19 +3,29 @@
 # Compose-backed command adapters used by vlei-workflow.sh.
 
 kli() {
-    workflow_compose run --rm --no-deps -T kli "$@"
+    local command_name="kli:${1:-unknown}"
+
+    # Include a nested subcommand such as "challenge:verify", but do not turn
+    # the first option of a flat command into part of its timing label.
+    case "${2:-}" in
+        ""|-*) ;;
+        *) command_name="${command_name}:${2}" ;;
+    esac
+
+    run_workflow_command \
+        command "${command_name}" "" \
+        workflow_compose exec -T kli kli "$@"
 }
 
 klid() {
     local logical_name=$1
     shift
-    run_background_compose_job kli "${logical_name}" "$@"
+    start_workflow_job \
+        "${logical_name}" "${logical_name}" kli "$@"
 }
 
 sig_tsx() {
-    run_background_compose_job signify signify-run "$@" ||
-        return 1
-    wait_for_background_job signify-run
+    workflow_compose exec -T signify tsx "$@"
 }
 
 wait_kli_jobs() {

--- a/qvi-workflow/keria_docker/lib/workflow-runtime.sh
+++ b/qvi-workflow/keria_docker/lib/workflow-runtime.sh
@@ -12,6 +12,11 @@ WORKFLOW_JOB_NAMES=("")
 WORKFLOW_JOB_PIDS=("")
 WORKFLOW_JOB_STDOUTS=("")
 WORKFLOW_JOB_STDERRS=("")
+WORKFLOW_JOB_RESOURCES=("")
+WORKFLOW_JOB_STARTS=("")
+WORKFLOW_JOB_RESULTS=("")
+WORKFLOW_COMPLETED_JOB_NAMES=("")
+WORKFLOW_COMPLETED_JOB_RESULTS=("")
 
 workflow_compose() {
     docker compose \
@@ -28,11 +33,13 @@ create_workflow_runtime() {
     LOCAL_QVI_DATA_DIR="${WORKFLOW_RUN_DIR}/qvi_data"
     KEYSTORE_DIR="${WORKFLOW_RUN_DIR}/keystores"
     WORKFLOW_LOG_DIR="${WORKFLOW_RUN_DIR}/logs"
+    WORKFLOW_RESULT_DIR="${WORKFLOW_RUN_DIR}/results"
     SALLY_CALLBACK_FILE="${WORKFLOW_RUN_DIR}/sally-callbacks.jsonl"
+    WORKFLOW_TIMING_FILE="${WORKFLOW_RUN_DIR}/workflow-timings.jsonl"
 
     export WORKFLOW_RUN_DIR WORKFLOW_CONFIG_DIR KLI_DATA_DIR
-    export LOCAL_QVI_DATA_DIR KEYSTORE_DIR WORKFLOW_LOG_DIR
-    export SALLY_CALLBACK_FILE
+    export LOCAL_QVI_DATA_DIR KEYSTORE_DIR WORKFLOW_LOG_DIR WORKFLOW_RESULT_DIR
+    export SALLY_CALLBACK_FILE WORKFLOW_TIMING_FILE
 
     # A retained --keep-runtime run is intentionally replaced by the next run.
     workflow_compose down --volumes --remove-orphans >/dev/null 2>&1 || true
@@ -44,7 +51,8 @@ create_workflow_runtime() {
         "${KLI_DATA_DIR}/temp-data" \
         "${LOCAL_QVI_DATA_DIR}" \
         "${KEYSTORE_DIR}" \
-        "${WORKFLOW_LOG_DIR}"
+        "${WORKFLOW_LOG_DIR}" \
+        "${WORKFLOW_RESULT_DIR}"
 
     cp -R "${SCRIPT_DIR}/config/." "${WORKFLOW_CONFIG_DIR}/"
     rm -f \
@@ -138,6 +146,104 @@ create_workflow_runtime() {
         }' > "${WORKFLOW_CONFIG_DIR}/participants.json"
 
     : > "${SALLY_CALLBACK_FILE}"
+    : > "${WORKFLOW_TIMING_FILE}"
+}
+
+record_workflow_timing() {
+    local kind=$1
+    local name=$2
+    local started_at=$3
+    local finished_at=$4
+    local status=$5
+    local resources=${6:-}
+
+    [[ -n "${WORKFLOW_TIMING_FILE:-}" ]] || return 0
+    jq -nc \
+        --arg kind "${kind}" \
+        --arg name "${name}" \
+        --arg resources "${resources}" \
+        --argjson startedAt "${started_at}" \
+        --argjson finishedAt "${finished_at}" \
+        --argjson duration "$((finished_at - started_at))" \
+        --argjson status "${status}" \
+        '{
+            kind: $kind,
+            name: $name,
+            resources: ($resources | split(",") | map(select(length > 0))),
+            startedAt: $startedAt,
+            finishedAt: $finishedAt,
+            durationSeconds: $duration,
+            status: $status
+        }' >> "${WORKFLOW_TIMING_FILE}"
+}
+
+run_workflow_phase() {
+    local phase_name=$1
+    shift
+    local started_at
+    local finished_at
+    local phase_status=0
+
+    started_at=$(date +%s)
+    "$@" || phase_status=$?
+    finished_at=$(date +%s)
+    record_workflow_timing \
+        phase "${phase_name}" "${started_at}" "${finished_at}" "${phase_status}"
+    return "${phase_status}"
+}
+
+run_workflow_command() {
+    local kind=$1
+    local command_name=$2
+    local resources=$3
+    shift 3
+    local started_at
+    local finished_at
+    local command_status=0
+
+    started_at=$(date +%s)
+    "$@" || command_status=$?
+    finished_at=$(date +%s)
+    record_workflow_timing \
+        "${kind}" "${command_name}" "${started_at}" "${finished_at}" \
+        "${command_status}" "${resources}"
+    return "${command_status}"
+}
+
+print_workflow_timing_summary() {
+    [[ -s "${WORKFLOW_TIMING_FILE:-}" ]] || return 0
+
+    print_lcyan "Workflow critical-path timing summary:"
+    jq -sr '
+        (map(.startedAt) | min) as $started |
+        (map(.finishedAt) | max) as $finished |
+        "total\tworkflow\t\($finished - $started)s",
+        (
+            map(select(.kind == "phase")) |
+            sort_by(.startedAt) |
+            .[] |
+            "phase\t\(.name)\t\(.durationSeconds)s\tstatus=\(.status)"
+        ),
+        (
+            map(select(.kind == "job")) |
+            sort_by(.durationSeconds) |
+            reverse |
+            .[0:10] |
+            .[] |
+            "slow-job\t\(.name)\t\(.durationSeconds)s\tstatus=\(.status)"
+        ),
+        (
+            map(select(.kind == "command")) |
+            sort_by(.durationSeconds) |
+            reverse |
+            .[0:15] |
+            .[] |
+            "slow-command\t\(.name)\t\(.durationSeconds)s\tstatus=\(.status)"
+        )
+    ' "${WORKFLOW_TIMING_FILE}" |
+        while IFS= read -r timing_line; do
+            print_lcyan "  ${timing_line}"
+        done
 }
 
 print_failure_diagnostics() {
@@ -182,6 +288,8 @@ workflow_cleanup() {
     if [[ "${workflow_failed}" == true ]]; then
         print_failure_diagnostics
     fi
+
+    cancel_all_workflow_jobs
 
     workflow_compose down --volumes --remove-orphans || cleanup_status=$?
     rm -rf "${WORKFLOW_RUN_DIR}"
@@ -280,95 +388,274 @@ background_job_has_stopped() {
     fi
 }
 
-run_background_compose_job() {
-    local service_name=$1
-    local logical_name=$2
-    shift 2
+workflow_resources_overlap() {
+    local left=$1
+    local right=$2
+    local left_resource
+    local right_resource
+    local old_ifs=${IFS}
+
+    IFS=,
+    for left_resource in ${left}; do
+        for right_resource in ${right}; do
+            if [[ -n "${left_resource}" &&
+                  "${left_resource}" == "${right_resource}" ]]; then
+                IFS=${old_ifs}
+                return 0
+            fi
+        done
+    done
+    IFS=${old_ifs}
+    return 1
+}
+
+register_background_job() {
+    local logical_name=$1
+    local resources=$2
+    local stdout_log=$3
+    local stderr_log=$4
+    local result_file=$5
+    local pid=$6
 
     local existing_name
-    local stdout_log="${WORKFLOW_LOG_DIR}/${logical_name}.out.log"
-    local stderr_log="${WORKFLOW_LOG_DIR}/${logical_name}.err.log"
+    local existing_resources
+    local index
     local job_index=${#WORKFLOW_JOB_NAMES[@]}
 
-    for existing_name in "${WORKFLOW_JOB_NAMES[@]}"; do
+    for index in "${!WORKFLOW_JOB_NAMES[@]}"; do
+        existing_name=${WORKFLOW_JOB_NAMES[${index}]}
         if [[ "${existing_name}" == "${logical_name}" ]]; then
             printf 'Background job %s is already active\n' "${logical_name}" >&2
             return 1
         fi
-    done
-
-    workflow_compose run --rm --no-deps -T \
-        "${service_name}" "$@" >"${stdout_log}" 2>"${stderr_log}" &
-    WORKFLOW_JOB_NAMES[${job_index}]="${logical_name}"
-    WORKFLOW_JOB_PIDS[${job_index}]=$!
-    WORKFLOW_JOB_STDOUTS[${job_index}]="${stdout_log}"
-    WORKFLOW_JOB_STDERRS[${job_index}]="${stderr_log}"
-}
-
-wait_for_background_job() {
-    local logical_name=$1
-    local job_index=-1
-    local index
-    local pid=""
-    local stdout_log=""
-    local stderr_log=""
-    local exit_status=125
-    local wait_completed=false
-
-    for index in "${!WORKFLOW_JOB_NAMES[@]}"; do
-        if [[ "${WORKFLOW_JOB_NAMES[${index}]}" == "${logical_name}" ]]; then
-            job_index=${index}
-            break
+        existing_resources=${WORKFLOW_JOB_RESOURCES[${index}]:-}
+        if workflow_resources_overlap "${resources}" "${existing_resources}"; then
+            printf 'Background job %s conflicts with active job %s on resources %s / %s\n' \
+                "${logical_name}" "${existing_name}" \
+                "${resources}" "${existing_resources}" >&2
+            return 1
         fi
     done
-    if [[ "${job_index}" -lt 0 ]]; then
-        printf 'No background job is registered as %s\n' "${logical_name}" >&2
-        return 1
-    fi
 
-    pid=${WORKFLOW_JOB_PIDS[${job_index}]}
-    stdout_log=${WORKFLOW_JOB_STDOUTS[${job_index}]}
-    stderr_log=${WORKFLOW_JOB_STDERRS[${job_index}]}
-    poll_until \
-        "background Compose job ${logical_name}" \
-        "${WORKFLOW_TIMEOUT_SECONDS}" \
-        background_job_has_stopped \
-        "${pid}" >/dev/null &&
-        wait_completed=true
+    WORKFLOW_JOB_NAMES[${job_index}]="${logical_name}"
+    WORKFLOW_JOB_PIDS[${job_index}]="${pid}"
+    WORKFLOW_JOB_STDOUTS[${job_index}]="${stdout_log}"
+    WORKFLOW_JOB_STDERRS[${job_index}]="${stderr_log}"
+    WORKFLOW_JOB_RESOURCES[${job_index}]="${resources}"
+    WORKFLOW_JOB_STARTS[${job_index}]="$(date +%s)"
+    WORKFLOW_JOB_RESULTS[${job_index}]="${result_file}"
+}
 
-    if [[ "${wait_completed}" == false ]]; then
-        kill "${pid}" 2>/dev/null || true
-        sleep 1
-        kill -9 "${pid}" 2>/dev/null || true
-        exit_status=124
-        wait "${pid}" 2>/dev/null || true
-    elif wait "${pid}"; then
-        exit_status=0
-    else
-        exit_status=$?
-    fi
+start_workflow_job() {
+    local logical_name=$1
+    local resources=$2
+    shift 2
 
+    local artifact_stem
+    local stdout_log
+    local stderr_log
+    local result_file
+    local pid
+
+    artifact_stem="${logical_name}-$(date -u +%Y%m%dT%H%M%SZ)-${RANDOM}"
+    stdout_log="${WORKFLOW_LOG_DIR}/${artifact_stem}.out.log"
+    stderr_log="${WORKFLOW_LOG_DIR}/${artifact_stem}.err.log"
+    result_file="${WORKFLOW_RESULT_DIR}/${artifact_stem}.json"
+
+    # Validate conflicts before launching so a rejected job cannot escape the
+    # workflow registry.
+    local existing_resources
+    local index
+    for index in "${!WORKFLOW_JOB_NAMES[@]}"; do
+        [[ -n "${WORKFLOW_JOB_NAMES[${index}]:-}" ]] || continue
+        existing_resources=${WORKFLOW_JOB_RESOURCES[${index}]:-}
+        if [[ "${WORKFLOW_JOB_NAMES[${index}]}" == "${logical_name}" ]] ||
+           workflow_resources_overlap "${resources}" "${existing_resources}"; then
+            printf 'Cannot start background job %s with resources %s\n' \
+                "${logical_name}" "${resources}" >&2
+            return 1
+        fi
+    done
+
+    "$@" >"${stdout_log}" 2>"${stderr_log}" &
+    pid=$!
+    register_background_job \
+        "${logical_name}" "${resources}" \
+        "${stdout_log}" "${stderr_log}" "${result_file}" "${pid}"
+}
+
+run_background_compose_job() {
+    local service_name=$1
+    local logical_name=$2
+    local resources=$3
+    shift 3
+
+    start_workflow_job \
+        "${logical_name}" "${resources}" \
+        workflow_compose exec -T "${service_name}" "$@"
+}
+
+find_workflow_job_index() {
+    local logical_name=$1
+    local index
+
+    for index in "${!WORKFLOW_JOB_NAMES[@]}"; do
+        if [[ "${WORKFLOW_JOB_NAMES[${index}]:-}" == "${logical_name}" ]]; then
+            printf '%s\n' "${index}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+finish_workflow_job() {
+    local job_index=$1
+    local exit_status=$2
+    local logical_name=${WORKFLOW_JOB_NAMES[${job_index}]}
+    local stdout_log=${WORKFLOW_JOB_STDOUTS[${job_index}]}
+    local stderr_log=${WORKFLOW_JOB_STDERRS[${job_index}]}
+    local resources=${WORKFLOW_JOB_RESOURCES[${job_index}]:-}
+    local started_at=${WORKFLOW_JOB_STARTS[${job_index}]}
+    local result_file=${WORKFLOW_JOB_RESULTS[${job_index}]}
+    local finished_at
+
+    finished_at=$(date +%s)
     [[ -f "${stdout_log}" ]] && cat "${stdout_log}"
     [[ -f "${stderr_log}" ]] && cat "${stderr_log}" >&2
+    record_workflow_timing \
+        job "${logical_name}" "${started_at}" "${finished_at}" \
+        "${exit_status}" "${resources}"
+    jq -n \
+        --arg name "${logical_name}" \
+        --arg resources "${resources}" \
+        --arg stdoutLog "${stdout_log}" \
+        --arg stderrLog "${stderr_log}" \
+        --argjson startedAt "${started_at}" \
+        --argjson finishedAt "${finished_at}" \
+        --argjson durationSeconds "$((finished_at - started_at))" \
+        --argjson status "${exit_status}" \
+        '{
+            name: $name,
+            resources: ($resources | split(",") | map(select(length > 0))),
+            startedAt: $startedAt,
+            finishedAt: $finishedAt,
+            durationSeconds: $durationSeconds,
+            status: $status,
+            stdoutLog: $stdoutLog,
+            stderrLog: $stderrLog
+        }' > "${result_file}"
+
+    local completed_index=${#WORKFLOW_COMPLETED_JOB_NAMES[@]}
+    WORKFLOW_COMPLETED_JOB_NAMES[${completed_index}]="${logical_name}"
+    WORKFLOW_COMPLETED_JOB_RESULTS[${completed_index}]="${result_file}"
+
     unset "WORKFLOW_JOB_NAMES[${job_index}]"
     unset "WORKFLOW_JOB_PIDS[${job_index}]"
     unset "WORKFLOW_JOB_STDOUTS[${job_index}]"
     unset "WORKFLOW_JOB_STDERRS[${job_index}]"
+    unset "WORKFLOW_JOB_RESOURCES[${job_index}]"
+    unset "WORKFLOW_JOB_STARTS[${job_index}]"
+    unset "WORKFLOW_JOB_RESULTS[${job_index}]"
+}
 
-    if [[ "${exit_status}" -ne 0 ]]; then
-        printf 'Background Compose job %s failed with status %s\n' \
-            "${logical_name}" "${exit_status}" >&2
-        return "${exit_status}"
-    fi
+workflow_job_result_file() {
+    local logical_name=$1
+    local index
+
+    # Return the most recent result when a logical name is reused in a later
+    # conflict-free wave.
+    for ((index=${#WORKFLOW_COMPLETED_JOB_NAMES[@]} - 1; index >= 1; index--)); do
+        if [[ "${WORKFLOW_COMPLETED_JOB_NAMES[${index}]:-}" == "${logical_name}" ]]; then
+            printf '%s\n' "${WORKFLOW_COMPLETED_JOB_RESULTS[${index}]}"
+            return 0
+        fi
+    done
+    printf 'No completed background job result is registered as %s\n' \
+        "${logical_name}" >&2
+    return 1
+}
+
+load_workflow_job_result() {
+    local logical_name=$1
+    local result_file
+
+    result_file=$(workflow_job_result_file "${logical_name}") || return 1
+    jq -e '.' "${result_file}"
+}
+
+cancel_all_workflow_jobs() {
+    local index
+    local pid
+    local active_jobs_found=false
+
+    for index in "${!WORKFLOW_JOB_NAMES[@]}"; do
+        [[ -n "${WORKFLOW_JOB_NAMES[${index}]:-}" ]] || continue
+        active_jobs_found=true
+        pid=${WORKFLOW_JOB_PIDS[${index}]}
+        kill "${pid}" 2>/dev/null || true
+    done
+    [[ "${active_jobs_found}" == true ]] || return 0
+    sleep 1
+    for index in "${!WORKFLOW_JOB_NAMES[@]}"; do
+        [[ -n "${WORKFLOW_JOB_NAMES[${index}]:-}" ]] || continue
+        pid=${WORKFLOW_JOB_PIDS[${index}]}
+        kill -9 "${pid}" 2>/dev/null || true
+        wait "${pid}" 2>/dev/null || true
+        finish_workflow_job "${index}" 143
+    done
+}
+
+wait_for_background_job() {
+    local logical_name=$1
+    wait_for_background_jobs "${logical_name}"
 }
 
 wait_for_background_jobs() {
+    local requested_names=("$@")
+    local deadline=$((SECONDS + WORKFLOW_TIMEOUT_SECONDS))
+    local remaining=${#requested_names[@]}
     local logical_name
-    local all_jobs_succeeded=true
+    local job_index
+    local pid
+    local exit_status
+    local made_progress
 
-    for logical_name in "$@"; do
-        wait_for_background_job "${logical_name}" ||
-            all_jobs_succeeded=false
+    for logical_name in "${requested_names[@]}"; do
+        find_workflow_job_index "${logical_name}" >/dev/null || {
+            printf 'No background job is registered as %s\n' "${logical_name}" >&2
+            return 1
+        }
     done
-    [[ "${all_jobs_succeeded}" == true ]]
+
+    while [[ "${remaining}" -gt 0 ]]; do
+        made_progress=false
+        for logical_name in "${requested_names[@]}"; do
+            job_index=$(find_workflow_job_index "${logical_name}") || continue
+            pid=${WORKFLOW_JOB_PIDS[${job_index}]}
+            if kill -0 "${pid}" 2>/dev/null; then
+                continue
+            fi
+
+            exit_status=0
+            wait "${pid}" || exit_status=$?
+            finish_workflow_job "${job_index}" "${exit_status}"
+            remaining=$((remaining - 1))
+            made_progress=true
+            if [[ "${exit_status}" -ne 0 ]]; then
+                printf 'Background job %s failed with status %s\n' \
+                    "${logical_name}" "${exit_status}" >&2
+                cancel_all_workflow_jobs
+                return "${exit_status}"
+            fi
+        done
+
+        [[ "${remaining}" -eq 0 ]] && break
+        if [[ "${SECONDS}" -ge "${deadline}" ]]; then
+            printf 'Timed out after %ss waiting for background job group: %s\n' \
+                "${WORKFLOW_TIMEOUT_SECONDS}" "${requested_names[*]}" >&2
+            cancel_all_workflow_jobs
+            return 124
+        fi
+        [[ "${made_progress}" == true ]] || sleep 1
+    done
 }

--- a/qvi-workflow/keria_docker/tests/workflow-contract-test.sh
+++ b/qvi-workflow/keria_docker/tests/workflow-contract-test.sh
@@ -13,6 +13,167 @@ fail_test() {
     exit 1
 }
 
+reset_job_registry() {
+    WORKFLOW_JOB_NAMES=("")
+    WORKFLOW_JOB_PIDS=("")
+    WORKFLOW_JOB_STDOUTS=("")
+    WORKFLOW_JOB_STDERRS=("")
+    WORKFLOW_JOB_RESOURCES=("")
+    WORKFLOW_JOB_STARTS=("")
+    WORKFLOW_JOB_RESULTS=("")
+    WORKFLOW_COMPLETED_JOB_NAMES=("")
+    WORKFLOW_COMPLETED_JOB_RESULTS=("")
+}
+
+test_background_job_contract() {
+    local test_runtime
+    local elapsed
+    local started_at
+
+    test_runtime=$(mktemp -d)
+    WORKFLOW_LOG_DIR="${test_runtime}/logs"
+    WORKFLOW_RESULT_DIR="${test_runtime}/results"
+    WORKFLOW_TIMING_FILE="${test_runtime}/timings.jsonl"
+    WORKFLOW_TIMEOUT_SECONDS=5
+    mkdir -p "${WORKFLOW_LOG_DIR}" "${WORKFLOW_RESULT_DIR}"
+    : > "${WORKFLOW_TIMING_FILE}"
+    reset_job_registry
+
+    timed_job() {
+        sleep 2
+    }
+    started_at=$(date +%s)
+    start_workflow_job timed-a actor-a timed_job
+    start_workflow_job timed-b actor-b timed_job
+    wait_for_background_jobs timed-a timed-b
+    elapsed=$(( $(date +%s) - started_at ))
+    [[ "${elapsed}" -lt 4 ]] ||
+        fail_test 'disjoint jobs did not execute concurrently'
+    [[ "$(jq -s 'length' "${WORKFLOW_TIMING_FILE}")" -eq 2 ]] ||
+        fail_test 'background job timings were not recorded'
+    [[ "$(find "${WORKFLOW_RESULT_DIR}" -type f -name '*.json' | wc -l | tr -d '[:space:]')" -eq 2 ]] ||
+        fail_test 'background job result files were not recorded'
+    jq -e -s \
+        'all(.[]; .status == 0 and (.stdoutLog | type == "string"))' \
+        "${WORKFLOW_RESULT_DIR}"/*.json >/dev/null ||
+        fail_test 'background job result files have the wrong contract'
+    load_workflow_job_result timed-a |
+        jq -e '.name == "timed-a" and .status == 0' >/dev/null ||
+        fail_test 'completed background job result could not be loaded'
+    run_workflow_command command contract-probe actor-probe true
+    jq -e -s \
+        'any(.[]; .kind == "command" and .name == "contract-probe" and .status == 0)' \
+        "${WORKFLOW_TIMING_FILE}" >/dev/null ||
+        fail_test 'foreground command timing was not recorded'
+
+    reset_job_registry
+    start_workflow_job conflict-a shared timed_job
+    if start_workflow_job conflict-b shared timed_job; then
+        fail_test 'resource-conflicting job was accepted'
+    fi
+    cancel_all_workflow_jobs
+
+    reset_job_registry
+    failing_job() { return 7; }
+    slow_job() { sleep 10; }
+    started_at=$(date +%s)
+    start_workflow_job failing actor-a failing_job
+    start_workflow_job slow actor-b slow_job
+    if wait_for_background_jobs failing slow; then
+        fail_test 'failed job group reported success'
+    fi
+    elapsed=$(( $(date +%s) - started_at ))
+    [[ "${elapsed}" -lt 5 ]] ||
+        fail_test 'failed job did not cancel its sibling promptly'
+
+    reset_job_registry
+    WORKFLOW_TIMEOUT_SECONDS=1
+    start_workflow_job deadline-a actor-a slow_job
+    start_workflow_job deadline-b actor-b slow_job
+    started_at=$(date +%s)
+    if wait_for_background_jobs deadline-a deadline-b; then
+        fail_test 'deadline-expired job group reported success'
+    else
+        [[ "$?" -eq 124 ]] ||
+            fail_test 'deadline-expired job group returned the wrong status'
+    fi
+    elapsed=$(( $(date +%s) - started_at ))
+    [[ "${elapsed}" -lt 5 ]] ||
+        fail_test 'job group did not enforce one bounded deadline'
+}
+
+test_delegation_queries_are_actor_disjoint() {
+    local approval_source
+
+    approval_source=$(declare -f approve_qvi_delegation)
+    [[ "${approval_source}" == *"query-qvi-for-gar1 gar1"* &&
+       "${approval_source}" == *"query-qvi-for-gar2 gar2"* ]] ||
+        fail_test 'GEDA participant queries do not use independent GAR lanes'
+    [[ "${approval_source}" == *"wait_for_background_jobs query-qvi-for-gar1 query-qvi-for-gar2"* ]] ||
+        fail_test 'GEDA participant query lanes do not share one deadline'
+}
+
+test_signal_cleanup_contract() {
+    local marker
+    local signal_status=0
+
+    marker=$(mktemp)
+    (
+        workflow_cleanup() {
+            printf 'cleanup:%s\n' "$1" > "${marker}"
+            return "$1"
+        }
+        install_workflow_traps
+        handle_workflow_signal TERM
+    ) || signal_status=$?
+
+    [[ "${signal_status}" -eq 143 ]] ||
+        fail_test 'TERM did not retain its signal exit status'
+    [[ "$(cat "${marker}")" == 'cleanup:143' ]] ||
+        fail_test 'TERM did not run workflow cleanup exactly once'
+    rm -f "${marker}"
+}
+
+test_challenge_matrix_contract() {
+    local relationship
+    local workflow_source="${WORKFLOW_DIR}/vlei-workflow.sh"
+
+    for relationship in \
+        GAR1-GAR2 LAR1-LAR2 QAR1-QAR2 QAR1-QAR3 \
+        QAR2-QAR3 GAR1-QAR1 QAR1-LAR1 QAR1-Person; do
+        grep -F "\"${relationship}|" "${workflow_source}" >/dev/null ||
+            fail_test "missing challenge relationship ${relationship}"
+    done
+    grep -F \
+        'Completed 16 directed responses across 8 trust relationships' \
+        "${workflow_source}" >/dev/null ||
+        fail_test 'challenge completion contract is not 16 directions'
+}
+
+test_final_revocation_wave_is_actor_disjoint() {
+    local optimized_source
+    local transmit_source
+    local refresh_line
+    local presentation_line
+
+    optimized_source=$(declare -f optimized_leaf_credential_pipeline)
+    transmit_source=$(declare -f transmit_revoked_oor_to_sally)
+    refresh_line=$(printf '%s\n' "${optimized_source}" |
+        grep -n 'refresh_person_revoked_oor_state' |
+        tail -n 1 |
+        cut -d: -f1)
+    presentation_line=$(printf '%s\n' "${optimized_source}" |
+        grep -n 'present-revoked-oor person,direct-sally' |
+        tail -n 1 |
+        cut -d: -f1)
+
+    [[ -n "${refresh_line}" && -n "${presentation_line}" &&
+       "${refresh_line}" -lt "${presentation_line}" ]] ||
+        fail_test 'holder refresh is not complete before the final revocation wave'
+    [[ "${transmit_source}" != *"--actor qvi"* ]] ||
+        fail_test 'revoked-OOR presentation still mutates the QVI in the ECR revocation wave'
+}
+
 test_rotation_failure_reaches_main_flow() {
     local marker
     marker=$(mktemp)
@@ -77,6 +238,7 @@ test_every_mode_uses_shared_qvi_lifecycle() {
         present_revoked_oor_to_sally() { return 0; }
         ecr_auth_and_ecr_cred() { return 0; }
         revoke_ecr_credential() { return 0; }
+        optimized_leaf_credential_pipeline() { return 0; }
         present_le_gleif_staging() { return 0; }
         present_le_gleif_production() { return 0; }
         present_le_to_alternate() { return 0; }
@@ -114,23 +276,25 @@ test_sally_startup_contract() {
         fail_test 'foundation startup included Sally'
 
     (
-        create_geda_multisig() {
+        create_foundational_multisigs_parallel() {
             GEDA_PRE=E-GEDA
+            LE_PRE=E-LE
             export GEDA_PRE
             order+=" geda"
         }
-        create_geda_reg() { order+=" registry"; }
-        start_sally() {
+        capture_foundational_group_oobis() { order+=" oobis"; }
+        create_foundational_state_parallel() {
             [[ -n "${GEDA_PRE:-}" ]] || return 1
-            order+=" sally"
+            order+=" registry+sally"
         }
         resolve_oobis() { order+=" resolve"; }
         challenge_response() { return 0; }
-        qars_resolve_geda_oobi() { return 0; }
         establish_qvi() { order+=" qvi"; }
+        create_qvi_reg() { order+=" qvi-registry"; }
 
         geda_delegation_to_qvi
-        [[ "${order}" == " geda registry sally resolve qvi" ]]
+        [[ "${order}" == \
+            " geda oobis registry+sally resolve qvi qvi-registry" ]]
     ) || fail_test 'Sally did not start exactly once after GEDA creation'
 
     if find "${WORKFLOW_DIR}/config" -name '*.json' -print0 |
@@ -151,4 +315,9 @@ test_sally_startup_contract() {
 test_rotation_failure_reaches_main_flow
 test_every_mode_uses_shared_qvi_lifecycle
 test_sally_startup_contract
+test_background_job_contract
+test_signal_cleanup_contract
+test_challenge_matrix_contract
+test_final_revocation_wave_is_actor_disjoint
+test_delegation_queries_are_actor_disjoint
 printf 'workflow contract passed\n'

--- a/qvi-workflow/keria_docker/vlei-workflow.sh
+++ b/qvi-workflow/keria_docker/vlei-workflow.sh
@@ -97,7 +97,9 @@ run_signify_json() {
 run_qvi_json() {
     local phase=$1
     shift
-    run_signify_json \
+    run_workflow_command \
+        command "signify:${phase}" "" \
+        run_signify_json \
         "${QVI_SIGNIFY_DIR}/sig-wallet.ts" \
         "${phase}" \
         --config "${QVI_PARTICIPANT_CONFIG}" \
@@ -346,7 +348,9 @@ function start_foundation_services() {
       keria1 \
       keria2 \
       keria3 \
-      keria4 ||
+      keria4 \
+      kli \
+      signify ||
       foundation_start_failed=true
   if [[ "${foundation_start_failed}" == true ]]; then
       fail_workflow "Docker foundation services failed to start properly"
@@ -357,24 +361,61 @@ function start_foundation_services() {
 # Verify the package versions exposed by every participating runtime before
 # any KERI state is created.
 function preflight_versions() {
-  local python_check='from importlib.metadata import version; import sys; actual=version(sys.argv[1]); expected=sys.argv[2]; print(f"{sys.argv[1]}={actual}"); raise SystemExit(0 if actual == expected else 1)'
-  local kli_version=""
+  start_workflow_job \
+      preflight-signify preflight-signify preflight_signify_versions ||
+      return 1
+  start_workflow_job \
+      preflight-keria preflight-keria preflight_keria_versions ||
+      return 1
+  start_workflow_job \
+      preflight-gar-witness preflight-gar-witness \
+      preflight_python_package gar-witnesses keri 1.3.1 ||
+      return 1
+  start_workflow_job \
+      preflight-qar-witness preflight-qar-witness \
+      preflight_python_package qar-witnesses keri 1.3.1 ||
+      return 1
+  start_workflow_job \
+      preflight-person-witness preflight-person-witness \
+      preflight_python_package person-witnesses keri 1.3.1 ||
+      return 1
+  start_workflow_job \
+      preflight-kli preflight-kli preflight_kli_version ||
+      return 1
+  wait_for_background_jobs \
+      preflight-signify \
+      preflight-keria \
+      preflight-gar-witness \
+      preflight-qar-witness \
+      preflight-person-witness \
+      preflight-kli
+}
 
-  run_qvi_json preflight >/dev/null || return 1
+preflight_signify_versions() {
+  run_qvi_json preflight >/dev/null
+}
+
+preflight_python_package() {
+  local service_name=$1
+  local package_name=$2
+  local expected_version=$3
+  local python_check='from importlib.metadata import version; import sys; actual=version(sys.argv[1]); expected=sys.argv[2]; print(f"{sys.argv[1]}={actual}"); raise SystemExit(0 if actual == expected else 1)'
+
+  workflow_compose exec -T "${service_name}" \
+      python -c "${python_check}" \
+      "${package_name}" "${expected_version}"
+}
+
+preflight_keria_versions() {
   workflow_compose exec -T keria1 \
-      python -c "${python_check}" keria 0.4.0 || return 1
-  workflow_compose exec -T keria1 \
-      python -c "${python_check}" keri 1.2.12 || return 1
-  # gleif/keri:1.2.9 is the image release; its installed KERIpy package is
-  # 1.3.1. Keep both expectations visible instead of conflating the versions.
-  workflow_compose exec -T gar-witnesses \
-      python -c "${python_check}" keri 1.3.1 || return 1
-  workflow_compose exec -T qar-witnesses \
-      python -c "${python_check}" keri 1.3.1 || return 1
-  workflow_compose exec -T person-witnesses \
-      python -c "${python_check}" keri 1.3.1 || return 1
+      python -c \
+      'from importlib.metadata import version; import sys; expected={"keria":"0.4.0","keri":"1.2.12"}; actual={name:version(name) for name in expected}; print(actual); raise SystemExit(0 if actual == expected else 1)'
+}
+
+preflight_kli_version() {
+  local kli_version
   kli_version=$(kli version) || return 1
-  [[ "${kli_version}" == *"1.1.32"* ]] || return 1
+  [[ "${kli_version}" == *"1.1.32"* ]]
 }
 
 function start_sally() {
@@ -487,15 +528,19 @@ load_sally_prefixes() {
   export DIRECT_SALLY_PRE
 }
 
-function setup_keria_identifiers() {
+create_keria_identifier_artifact() {
+  run_qvi_json ms-setup > "${WORKFLOW_RUN_DIR}/keria-setup.json"
+}
+
+load_keria_identifier_artifact() {
   local setup_failed=false
   local qvi_setup_data=""
   local setup_fields=""
 
-  print_yellow "Creating QVI and Person Identifiers from SignifyTS + KERIA"
-  qvi_setup_data=$(run_qvi_json ms-setup) || setup_failed=true
+  qvi_setup_data=$(jq -c . "${WORKFLOW_RUN_DIR}/keria-setup.json") ||
+      setup_failed=true
   if [[ "${setup_failed}" == true ]]; then
-      fail_workflow "Unable to create the QAR and Person identifiers"
+      fail_workflow "Unable to load the QAR and Person identifier evidence"
   fi
 
   print_green "QVI and Person Identifiers from SignifyTS + KERIA are "
@@ -542,20 +587,44 @@ function setup_keria_identifiers() {
   print_dark_gray "Person   OOBI: $PERSON_OOBI"
 }
 
+function setup_keria_identifiers() {
+  print_yellow "Creating QVI and Person Identifiers from SignifyTS + KERIA"
+  create_keria_identifier_artifact || return 1
+  load_keria_identifier_artifact
+}
+
 function resolve_gar_oobis() {
     GAR1_OOBI="${WIT_HOST_GAR}/oobi/${GAR1_PRE}/witness/${WAN_PRE}"
     GAR2_OOBI="${WIT_HOST_GAR}/oobi/${GAR2_PRE}/witness/${WAN_PRE}"
 
-    kli oobi resolve \
-        --name "${GAR1}" \
-        --oobi-alias "${GAR2}" \
-        --passcode "${GAR1_PASSCODE}" \
-        --oobi "${GAR2_OOBI}" || return 1
-    kli oobi resolve \
-        --name "${GAR2}" \
-        --oobi-alias "${GAR1}" \
-        --passcode "${GAR2_PASSCODE}" \
-        --oobi "${GAR1_OOBI}" || return 1
+    start_workflow_job \
+        resolve-gar1-member gar1 resolve_kli_observer_oobis \
+        "${GAR1}" "${GAR1_PASSCODE}" "${GAR2}|${GAR2_OOBI}" || return 1
+    start_workflow_job \
+        resolve-gar2-member gar2 resolve_kli_observer_oobis \
+        "${GAR2}" "${GAR2_PASSCODE}" "${GAR1}|${GAR1_OOBI}" || return 1
+    wait_for_background_jobs resolve-gar1-member resolve-gar2-member
+}
+
+function resolve_lar_oobis() {
+    LAR1_OOBI="${WIT_HOST_QAR}/oobi/${LAR1_PRE}/witness/${WIL_PRE}"
+    LAR2_OOBI="${WIT_HOST_QAR}/oobi/${LAR2_PRE}/witness/${WIL_PRE}"
+
+    start_workflow_job \
+        resolve-lar1-member lar1 resolve_kli_observer_oobis \
+        "${LAR1}" "${LAR1_PASSCODE}" "${LAR2}|${LAR2_OOBI}" || return 1
+    start_workflow_job \
+        resolve-lar2-member lar2 resolve_kli_observer_oobis \
+        "${LAR2}" "${LAR2_PASSCODE}" "${LAR1}|${LAR1_OOBI}" || return 1
+    wait_for_background_jobs resolve-lar1-member resolve-lar2-member
+}
+
+resolve_foundational_member_oobis() {
+    start_workflow_job \
+        resolve-gar-members gar1,gar2 resolve_gar_oobis || return 1
+    start_workflow_job \
+        resolve-lar-members lar1,lar2 resolve_lar_oobis || return 1
+    wait_for_background_jobs resolve-gar-members resolve-lar-members
 }
 
 # initializes a keystore and creates a single sig AID
@@ -597,6 +666,38 @@ function create_aids() {
     create_aid "${LAR2}" "${LAR2_SALT}" "${LAR2_PASSCODE}" "${CONT_CONFIG_DIR}" "habery-cfg-qars.json" "/config/incept-cfg-qars.json"
 }
 
+setup_participant_identifiers_parallel() {
+    print_green "------------------------------Creating identifiers (AIDs)------------------------------"
+    start_workflow_job \
+        setup-keria qar1,qar2,qar3,qar4,person \
+        create_keria_identifier_artifact || return 1
+    start_workflow_job \
+        setup-gar1 gar1 \
+        create_aid "${GAR1}" "${GAR1_SALT}" "${GAR1_PASSCODE}" \
+        "${CONT_CONFIG_DIR}" "habery-cfg-gars.json" \
+        "/config/incept-cfg-gars.json" || return 1
+    start_workflow_job \
+        setup-gar2 gar2 \
+        create_aid "${GAR2}" "${GAR2_SALT}" "${GAR2_PASSCODE}" \
+        "${CONT_CONFIG_DIR}" "habery-cfg-gars.json" \
+        "/config/incept-cfg-gars.json" || return 1
+    start_workflow_job \
+        setup-lar1 lar1 \
+        create_aid "${LAR1}" "${LAR1_SALT}" "${LAR1_PASSCODE}" \
+        "${CONT_CONFIG_DIR}" "habery-cfg-qars.json" \
+        "/config/incept-cfg-qars.json" || return 1
+    start_workflow_job \
+        setup-lar2 lar2 \
+        create_aid "${LAR2}" "${LAR2_SALT}" "${LAR2_PASSCODE}" \
+        "${CONT_CONFIG_DIR}" "habery-cfg-qars.json" \
+        "/config/incept-cfg-qars.json" || return 1
+    wait_for_background_jobs \
+        setup-keria setup-gar1 setup-gar2 setup-lar1 setup-lar2 ||
+        return 1
+    load_keria_identifier_artifact || return 1
+    read_prefixes
+}
+
 function read_prefixes() {
   GAR1_PRE=$(kli status --name "${GAR1}" --alias "${GAR1}" \
       --passcode "${GAR1_PASSCODE}" |
@@ -623,74 +724,85 @@ function read_prefixes() {
   print_lcyan "LAR2 Prefix: ${LAR2_PRE}"
 }
 
-# OOBI resolutions between single sig AIDs
+resolve_kli_observer_oobis() {
+    local observer_name=$1
+    local observer_passcode=$2
+    shift 2
+    local oobi_record
+    local alias
+    local oobi
+
+    for oobi_record in "$@"; do
+        IFS='|' read -r alias oobi <<< "${oobi_record}"
+        kli oobi resolve \
+            --name "${observer_name}" \
+            --oobi-alias "${alias}" \
+            --passcode "${observer_passcode}" \
+            --oobi "${oobi}" || return 1
+    done
+}
+
+resolve_keria_external_oobis() {
+    run_qvi_json \
+        ms-resolve-external \
+        --oobis "${OOBIS_FOR_KERIA}" >/dev/null
+}
+
+# Resolve each observer's independent contact graph concurrently.
 function resolve_oobis() {
-    local resolution_failed=false
-
     DIRECT_SALLY_OOBI="${DIRECT_SALLY_HOST}/oobi"
-    print_green "DIRECT SALLY OOBI: ${DIRECT_SALLY_OOBI}"
-
     GAR1_OOBI="${WIT_HOST_GAR}/oobi/${GAR1_PRE}/witness/${WAN_PRE}"
     GAR2_OOBI="${WIT_HOST_GAR}/oobi/${GAR2_PRE}/witness/${WAN_PRE}"
     LAR1_OOBI="${WIT_HOST_QAR}/oobi/${LAR1_PRE}/witness/${WIL_PRE}"
     LAR2_OOBI="${WIT_HOST_QAR}/oobi/${LAR2_PRE}/witness/${WIL_PRE}"
-    OOBIS_FOR_KERIA="gar1|$GAR1_OOBI,gar2|$GAR2_OOBI,lar1|$LAR1_OOBI,lar2|$LAR2_OOBI,direct-sally|$DIRECT_SALLY_OOBI"
+    OOBIS_FOR_KERIA="gar1|${GAR1_OOBI},gar2|${GAR2_OOBI},lar1|${LAR1_OOBI},lar2|${LAR2_OOBI},direct-sally|${DIRECT_SALLY_OOBI}"
+    export OOBIS_FOR_KERIA
 
-    run_qvi_json \
-        ms-resolve-external \
-        --oobis "${OOBIS_FOR_KERIA}" >/dev/null ||
-        resolution_failed=true
-    if [[ "${resolution_failed}" == true ]]; then
-        fail_workflow "KERIA participants could not resolve the workflow OOBIs"
-    fi
-
-    echo
+    print_green "DIRECT SALLY OOBI: ${DIRECT_SALLY_OOBI}"
     print_green "------------------------------Connecting Keystores with OOBI Resolutions------------------------------"
-    print_yellow "Resolving OOBIs for GAR 1"
-    kli oobi resolve --name "${GAR1}" --oobi-alias "${GAR2}"   --passcode "${GAR1_PASSCODE}" --oobi "${GAR2_OOBI}"
-    kli oobi resolve --name "${GAR1}" --oobi-alias "${LAR1}"   --passcode "${GAR1_PASSCODE}" --oobi "${LAR1_OOBI}"
-    kli oobi resolve --name "${GAR1}" --oobi-alias "${LAR2}"   --passcode "${GAR1_PASSCODE}" --oobi "${LAR2_OOBI}"
-    kli oobi resolve --name "${GAR1}" --oobi-alias "${QAR1}"   --passcode "${GAR1_PASSCODE}" --oobi "${QAR1_OOBI}" 
-    kli oobi resolve --name "${GAR1}" --oobi-alias "${QAR2}"   --passcode "${GAR1_PASSCODE}" --oobi "${QAR2_OOBI}" 
-    kli oobi resolve --name "${GAR1}" --oobi-alias "${QAR3}"   --passcode "${GAR1_PASSCODE}" --oobi "${QAR3_OOBI}"
-    kli oobi resolve --name "${GAR1}" --oobi-alias "${QAR4}"   --passcode "${GAR1_PASSCODE}" --oobi "${QAR4_OOBI}"
-    kli oobi resolve --name "${GAR1}" --oobi-alias "${PERSON}" --passcode "${GAR1_PASSCODE}" --oobi "${PERSON_OOBI}"
-    kli oobi resolve --name "${GAR1}" --oobi-alias "${DIRECT_SALLY_ALIAS}"   --passcode "${GAR1_PASSCODE}" --oobi "${DIRECT_SALLY_OOBI}"
 
-    print_yellow "Resolving OOBIs for GAR 2"
-    kli oobi resolve --name "${GAR2}" --oobi-alias "${GAR1}"   --passcode "${GAR2_PASSCODE}" --oobi "${GAR1_OOBI}"
-    kli oobi resolve --name "${GAR2}" --oobi-alias "${LAR1}"   --passcode "${GAR2_PASSCODE}" --oobi "${LAR1_OOBI}"
-    kli oobi resolve --name "${GAR2}" --oobi-alias "${LAR2}"   --passcode "${GAR2_PASSCODE}" --oobi "${LAR2_OOBI}"
-    kli oobi resolve --name "${GAR2}" --oobi-alias "${QAR1}"   --passcode "${GAR2_PASSCODE}" --oobi "${QAR1_OOBI}"
-    kli oobi resolve --name "${GAR2}" --oobi-alias "${QAR2}"   --passcode "${GAR2_PASSCODE}" --oobi "${QAR2_OOBI}"
-    kli oobi resolve --name "${GAR2}" --oobi-alias "${QAR3}"   --passcode "${GAR2_PASSCODE}" --oobi "${QAR3_OOBI}"
-    kli oobi resolve --name "${GAR2}" --oobi-alias "${QAR4}"   --passcode "${GAR2_PASSCODE}" --oobi "${QAR4_OOBI}"
-    kli oobi resolve --name "${GAR2}" --oobi-alias "${PERSON}" --passcode "${GAR2_PASSCODE}" --oobi "${PERSON_OOBI}"
-    kli oobi resolve --name "${GAR2}" --oobi-alias "${DIRECT_SALLY_ALIAS}"   --passcode "${GAR2_PASSCODE}" --oobi "${DIRECT_SALLY_OOBI}"
+    start_workflow_job \
+        resolve-keria-oobis qar1,qar2,qar3,qar4,person \
+        resolve_keria_external_oobis || return 1
+    start_workflow_job \
+        resolve-gar1-oobis gar1 resolve_kli_observer_oobis \
+        "${GAR1}" "${GAR1_PASSCODE}" \
+        "${GAR2}|${GAR2_OOBI}" "${LAR1}|${LAR1_OOBI}" \
+        "${LAR2}|${LAR2_OOBI}" "${QAR1}|${QAR1_OOBI}" \
+        "${QAR2}|${QAR2_OOBI}" "${QAR3}|${QAR3_OOBI}" \
+        "${QAR4}|${QAR4_OOBI}" "${PERSON}|${PERSON_OOBI}" \
+        "${DIRECT_SALLY_ALIAS}|${DIRECT_SALLY_OOBI}" || return 1
+    start_workflow_job \
+        resolve-gar2-oobis gar2 resolve_kli_observer_oobis \
+        "${GAR2}" "${GAR2_PASSCODE}" \
+        "${GAR1}|${GAR1_OOBI}" "${LAR1}|${LAR1_OOBI}" \
+        "${LAR2}|${LAR2_OOBI}" "${QAR1}|${QAR1_OOBI}" \
+        "${QAR2}|${QAR2_OOBI}" "${QAR3}|${QAR3_OOBI}" \
+        "${QAR4}|${QAR4_OOBI}" "${PERSON}|${PERSON_OOBI}" \
+        "${DIRECT_SALLY_ALIAS}|${DIRECT_SALLY_OOBI}" || return 1
+    start_workflow_job \
+        resolve-lar1-oobis lar1 resolve_kli_observer_oobis \
+        "${LAR1}" "${LAR1_PASSCODE}" \
+        "${LAR2}|${LAR2_OOBI}" "${GAR1}|${GAR1_OOBI}" \
+        "${GAR2}|${GAR2_OOBI}" "${QAR1}|${QAR1_OOBI}" \
+        "${QAR2}|${QAR2_OOBI}" "${QAR3}|${QAR3_OOBI}" \
+        "${QAR4}|${QAR4_OOBI}" "${PERSON}|${PERSON_OOBI}" \
+        "${DIRECT_SALLY_ALIAS}|${DIRECT_SALLY_OOBI}" || return 1
+    start_workflow_job \
+        resolve-lar2-oobis lar2 resolve_kli_observer_oobis \
+        "${LAR2}" "${LAR2_PASSCODE}" \
+        "${LAR1}|${LAR1_OOBI}" "${GAR1}|${GAR1_OOBI}" \
+        "${GAR2}|${GAR2_OOBI}" "${QAR1}|${QAR1_OOBI}" \
+        "${QAR2}|${QAR2_OOBI}" "${QAR3}|${QAR3_OOBI}" \
+        "${QAR4}|${QAR4_OOBI}" "${PERSON}|${PERSON_OOBI}" \
+        "${DIRECT_SALLY_ALIAS}|${DIRECT_SALLY_OOBI}" || return 1
 
-    print_yellow "Resolving OOBIs for LAR 1"
-    kli oobi resolve --name "${LAR1}" --oobi-alias "${LAR2}"   --passcode "${LAR1_PASSCODE}" --oobi "${LAR2_OOBI}"
-    kli oobi resolve --name "${LAR1}" --oobi-alias "${GAR1}"   --passcode "${LAR1_PASSCODE}" --oobi "${GAR1_OOBI}"
-    kli oobi resolve --name "${LAR1}" --oobi-alias "${GAR2}"   --passcode "${LAR1_PASSCODE}" --oobi "${GAR2_OOBI}"
-    kli oobi resolve --name "${LAR1}" --oobi-alias "${QAR1}"   --passcode "${LAR1_PASSCODE}" --oobi "${QAR1_OOBI}"
-    kli oobi resolve --name "${LAR1}" --oobi-alias "${QAR2}"   --passcode "${LAR1_PASSCODE}" --oobi "${QAR2_OOBI}"
-    kli oobi resolve --name "${LAR1}" --oobi-alias "${QAR3}"   --passcode "${LAR1_PASSCODE}" --oobi "${QAR3_OOBI}"
-    kli oobi resolve --name "${LAR1}" --oobi-alias "${QAR4}"   --passcode "${LAR1_PASSCODE}" --oobi "${QAR4_OOBI}"
-    kli oobi resolve --name "${LAR1}" --oobi-alias "${PERSON}" --passcode "${LAR1_PASSCODE}" --oobi "${PERSON_OOBI}"
-    kli oobi resolve --name "${LAR1}" --oobi-alias "${DIRECT_SALLY_ALIAS}"   --passcode "${LAR1_PASSCODE}" --oobi "${DIRECT_SALLY_OOBI}"
-
-    print_yellow "Resolving OOBIs for LAR 2"
-    kli oobi resolve --name "${LAR2}" --oobi-alias "${LAR1}"   --passcode "${LAR2_PASSCODE}" --oobi "${LAR1_OOBI}"
-    kli oobi resolve --name "${LAR2}" --oobi-alias "${GAR1}"   --passcode "${LAR2_PASSCODE}" --oobi "${GAR1_OOBI}"
-    kli oobi resolve --name "${LAR2}" --oobi-alias "${GAR2}"   --passcode "${LAR2_PASSCODE}" --oobi "${GAR2_OOBI}"
-    kli oobi resolve --name "${LAR2}" --oobi-alias "${QAR1}"   --passcode "${LAR2_PASSCODE}" --oobi "${QAR1_OOBI}"
-    kli oobi resolve --name "${LAR2}" --oobi-alias "${QAR2}"   --passcode "${LAR2_PASSCODE}" --oobi "${QAR2_OOBI}"
-    kli oobi resolve --name "${LAR2}" --oobi-alias "${QAR3}"   --passcode "${LAR2_PASSCODE}" --oobi "${QAR3_OOBI}"
-    kli oobi resolve --name "${LAR2}" --oobi-alias "${QAR4}"   --passcode "${LAR2_PASSCODE}" --oobi "${QAR4_OOBI}"
-    kli oobi resolve --name "${LAR2}" --oobi-alias "${PERSON}" --passcode "${LAR2_PASSCODE}" --oobi "${PERSON_OOBI}"
-    kli oobi resolve --name "${LAR2}" --oobi-alias "${DIRECT_SALLY_ALIAS}"   --passcode "${LAR2_PASSCODE}" --oobi "${DIRECT_SALLY_OOBI}"
-    
-    echo
+    wait_for_background_jobs \
+        resolve-keria-oobis \
+        resolve-gar1-oobis \
+        resolve-gar2-oobis \
+        resolve-lar1-oobis \
+        resolve-lar2-oobis
 }
 
 CHALLENGE_WORDS=""
@@ -896,12 +1008,8 @@ load_challenge_participant() {
     esac
 }
 
-function challenge_response() {
-  local relationships=(
-      "QAR1-QAR2|qar1|qar2"
-      "GAR1-QAR1|gar1|qar1"
-  )
-  local relationship_record
+challenge_relationship_record() {
+  local relationship_record=$1
   local relationship
   local left_id
   local right_id
@@ -914,29 +1022,64 @@ function challenge_response() {
   local right_passcode
   local right_prefix
 
+  IFS='|' read -r relationship left_id right_id <<< "${relationship_record}"
+
+  load_challenge_participant "${left_id}"
+  left_type="${CHALLENGE_PARTICIPANT_TYPE}"
+  left_name="${CHALLENGE_PARTICIPANT_NAME}"
+  left_passcode="${CHALLENGE_PARTICIPANT_PASSCODE}"
+  left_prefix="${CHALLENGE_PARTICIPANT_PREFIX}"
+
+  load_challenge_participant "${right_id}"
+  right_type="${CHALLENGE_PARTICIPANT_TYPE}"
+  right_name="${CHALLENGE_PARTICIPANT_NAME}"
+  right_passcode="${CHALLENGE_PARTICIPANT_PASSCODE}"
+  right_prefix="${CHALLENGE_PARTICIPANT_PREFIX}"
+
+  challenge_relationship "${relationship}" \
+      "${left_type}" "${left_id}" "${left_name}" "${left_passcode}" "${left_prefix}" \
+      "${right_type}" "${right_id}" "${right_name}" "${right_passcode}" "${right_prefix}"
+}
+
+run_challenge_wave() {
+  local relationship_record
+  local relationship
+  local left_id
+  local right_id
+  local job_names=""
+
+  for relationship_record in "$@"; do
+      IFS='|' read -r relationship left_id right_id <<< "${relationship_record}"
+      job_names="${job_names} challenge-${relationship}"
+      start_workflow_job \
+          "challenge-${relationship}" "${left_id},${right_id}" \
+          challenge_relationship_record "${relationship_record}" ||
+          return 1
+  done
+  # Job names are generated from fixed relationship labels and contain no
+  # whitespace, so intentional word splitting supplies the group members.
+  # shellcheck disable=SC2086
+  wait_for_background_jobs ${job_names}
+}
+
+function challenge_response() {
   print_green "------------------------------Authenticating Keystore control with Challenge Responses------------------------------"
 
-  for relationship_record in "${relationships[@]}"; do
-      IFS='|' read -r relationship left_id right_id <<< "${relationship_record}"
+  run_challenge_wave \
+      "GAR1-GAR2|gar1|gar2" \
+      "LAR1-LAR2|lar1|lar2" \
+      "QAR1-QAR2|qar1|qar2" || return 1
+  run_challenge_wave \
+      "QAR1-QAR3|qar1|qar3" || return 1
+  run_challenge_wave \
+      "QAR2-QAR3|qar2|qar3" \
+      "GAR1-QAR1|gar1|qar1" || return 1
+  run_challenge_wave \
+      "QAR1-LAR1|qar1|lar1" || return 1
+  run_challenge_wave \
+      "QAR1-Person|qar1|person" || return 1
 
-      load_challenge_participant "${left_id}"
-      left_type="${CHALLENGE_PARTICIPANT_TYPE}"
-      left_name="${CHALLENGE_PARTICIPANT_NAME}"
-      left_passcode="${CHALLENGE_PARTICIPANT_PASSCODE}"
-      left_prefix="${CHALLENGE_PARTICIPANT_PREFIX}"
-
-      load_challenge_participant "${right_id}"
-      right_type="${CHALLENGE_PARTICIPANT_TYPE}"
-      right_name="${CHALLENGE_PARTICIPANT_NAME}"
-      right_passcode="${CHALLENGE_PARTICIPANT_PASSCODE}"
-      right_prefix="${CHALLENGE_PARTICIPANT_PREFIX}"
-
-      challenge_relationship "${relationship}" \
-          "${left_type}" "${left_id}" "${left_name}" "${left_passcode}" "${left_prefix}" \
-          "${right_type}" "${right_id}" "${right_name}" "${right_passcode}" "${right_prefix}"
-  done
-
-  print_green "[challenge] Completed 4 directed responses across 2 trust relationships"
+  print_green "[challenge] Completed 16 directed responses across 8 trust relationships"
 }
 
 ################# Create Multisigs and perform delegation ################
@@ -945,6 +1088,7 @@ function create_multisig_icp_config() {
     PRE1=$1
     PRE2=$2
     local wit_pre=$3
+    local output_file=$4
     jq \
         --arg first_aid "${PRE1}" \
         --arg second_aid "${PRE2}" \
@@ -952,24 +1096,26 @@ function create_multisig_icp_config() {
         '.aids = [$first_aid, $second_aid] |
          .wits = [$witness]' \
         "${WORKFLOW_CONFIG_DIR}/template-multi-sig-incept-config.jq" \
-        > "${WORKFLOW_CONFIG_DIR}/multi-sig-incept-config.json"
+        > "${WORKFLOW_CONFIG_DIR}/${output_file}"
 
     print_lcyan "Multisig inception config JSON:"
-    print_lcyan "$(cat "${WORKFLOW_CONFIG_DIR}/multi-sig-incept-config.json")"
+    print_lcyan "$(cat "${WORKFLOW_CONFIG_DIR}/${output_file}")"
 }
 
 function create_geda_multisig() {
     echo
     print_yellow "[External] Multisig Inception for GEDA"
 
-    create_multisig_icp_config "${GAR1_PRE}" "${GAR2_PRE}" "${WAN_PRE}"
+    create_multisig_icp_config \
+        "${GAR1_PRE}" "${GAR2_PRE}" "${WAN_PRE}" \
+        "geda-multisig-incept-config.json"
 
     # The following multisig commands run in parallel in Docker
     print_yellow "[External] Multisig Inception from ${GAR1}: ${GAR1_PRE}"
     klid gar1 multisig incept --name "${GAR1}" --alias "${GAR1}" \
         --passcode "${GAR1_PASSCODE}" \
         --group "${GEDA_NAME}" \
-        --file /config/multi-sig-incept-config.json
+        --file /config/geda-multisig-incept-config.json
 
     echo
 
@@ -1003,7 +1149,13 @@ function qars_resolve_geda_oobi() {
     local geda_resolution_failed=false
     local refresh_failed=false
 
-    GEDA_OOBI=$(kli oobi generate --name "${GAR1}" --passcode "${GAR1_PASSCODE}" --alias "${GEDA_NAME}" --role witness)
+    if [[ -z "${GEDA_OOBI:-}" ]]; then
+        GEDA_OOBI=$(kli oobi generate \
+            --name "${GAR1}" \
+            --passcode "${GAR1_PASSCODE}" \
+            --alias "${GEDA_NAME}" \
+            --role witness)
+    fi
     [[ -z "${GEDA_OOBI}" ]] && geda_oobi_is_missing=true
     if [[ "${geda_oobi_is_missing}" == true ]]; then
         print_red "Failed to generate GEDA OOBI"
@@ -1091,21 +1243,32 @@ function create_qvi_multisig() {
     print_green "[QVI] Multisig AID ${QVI_NAME} with prefix: ${QVI_PRE}"
 }
 
-approve_qvi_delegation() {
+query_qvi_participants_for_geda_member() {
+    local member_name=$1
+    local member_passcode=$2
+    shift 2
     local participant_prefix
 
     for participant_prefix in "$@"; do
         kli query \
-            --name "${GAR1}" \
+            --name "${member_name}" \
             --alias "${GEDA_NAME}" \
-            --passcode "${GAR1_PASSCODE}" \
-            --prefix "${participant_prefix}" >/dev/null || return 1
-        kli query \
-            --name "${GAR2}" \
-            --alias "${GEDA_NAME}" \
-            --passcode "${GAR2_PASSCODE}" \
+            --passcode "${member_passcode}" \
             --prefix "${participant_prefix}" >/dev/null || return 1
     done
+}
+
+approve_qvi_delegation() {
+    start_workflow_job \
+        query-qvi-for-gar1 gar1 \
+        query_qvi_participants_for_geda_member \
+        "${GAR1}" "${GAR1_PASSCODE}" "$@" || return 1
+    start_workflow_job \
+        query-qvi-for-gar2 gar2 \
+        query_qvi_participants_for_geda_member \
+        "${GAR2}" "${GAR2_PASSCODE}" "$@" || return 1
+    wait_for_background_jobs query-qvi-for-gar1 query-qvi-for-gar2 ||
+        return 1
 
     klid gar1 delegate confirm \
         --name "${GAR1}" \
@@ -1252,14 +1415,16 @@ function create_le_multisig() {
     echo
     print_yellow "[LE] Multisig Inception for LE"
 
-    create_multisig_icp_config "${LAR1_PRE}" "${LAR2_PRE}" "${WIL_PRE}"
+    create_multisig_icp_config \
+        "${LAR1_PRE}" "${LAR2_PRE}" "${WIL_PRE}" \
+        "le-multisig-incept-config.json"
 
     # Follow commands run in parallel
     print_yellow "[LE] Multisig Inception from ${LAR1}: ${LAR1_PRE}"
     klid lar1 multisig incept --name "${LAR1}" --alias "${LAR1}" \
         --passcode "${LAR1_PASSCODE}" \
         --group "${LE_NAME}" \
-        --file /config/multi-sig-incept-config.json
+        --file /config/le-multisig-incept-config.json
 
     echo
 
@@ -1293,7 +1458,13 @@ function qars_resolve_le_oobi() {
     local le_oobi_is_missing=false
     local le_resolution_failed=false
 
-    LE_OOBI=$(kli oobi generate --name "${LAR1}" --passcode "${LAR1_PASSCODE}" --alias "${LE_NAME}" --role witness)
+    if [[ -z "${LE_OOBI:-}" ]]; then
+        LE_OOBI=$(kli oobi generate \
+            --name "${LAR1}" \
+            --passcode "${LAR1_PASSCODE}" \
+            --alias "${LE_NAME}" \
+            --role witness)
+    fi
     [[ -z "${LE_OOBI}" ]] && le_oobi_is_missing=true
     if [[ "${le_oobi_is_missing}" == true ]]; then
         print_red "Failed to generate LE OOBI"
@@ -1583,7 +1754,32 @@ record_qvi_issuance_result() {
     )
 }
 
-function create_and_grant_le_credential() {
+store_qvi_issuance_result() {
+    local credential_kind=$1
+    local issuance_result=$2
+    printf '%s\n' "${issuance_result}" \
+        > "${WORKFLOW_RUN_DIR}/${credential_kind}-issuance.json"
+}
+
+load_qvi_issuance_result() {
+    local credential_kind=$1
+    local credential_said
+
+    credential_said=$(jq -r \
+        '.credentialSaid' \
+        "${WORKFLOW_RUN_DIR}/${credential_kind}-issuance.json") ||
+        return 1
+    [[ -n "${credential_said}" && "${credential_said}" != null ]] ||
+        return 1
+    case "${credential_kind}" in
+        le) LE_CRED_SAID=${credential_said} ;;
+        oor) OOR_CRED_SAID=${credential_said} ;;
+        ecr) ECR_CRED_SAID=${credential_said} ;;
+        *) return 1 ;;
+    esac
+}
+
+function create_le_credential() {
     local issuance_result=""
     local issuance_failed=false
 
@@ -1603,8 +1799,9 @@ function create_and_grant_le_credential() {
       --issuee-prefix "${LE_PRE}") ||
       issuance_failed=true
     if [[ "${issuance_failed}" == true ]]; then
-        fail_workflow "[QVI] Failed to create and grant the LE credential"
+        fail_workflow "[QVI] Failed to create the LE credential"
     fi
+    store_qvi_issuance_result le "${issuance_result}"
     record_qvi_issuance_result "${issuance_result}"
     LE_CRED_SAID="${LAST_ISSUED_CREDENTIAL_SAID}"
     assert_qvi_credential_state \
@@ -1613,22 +1810,60 @@ function create_and_grant_le_credential() {
         "${LE_SCHEMA}" \
         "${LE_PRE}" \
         0
+}
+
+function grant_le_credential() {
+    run_qvi_json \
+        ms-grant \
+        --credential-said "${LE_CRED_SAID}" \
+        --recipient-prefix "${LE_PRE}" >/dev/null ||
+        fail_workflow "[QVI] Failed to grant the LE credential"
 
     echo
-    print_lcyan "[QVI] LE Credential created"
+    print_lcyan "[QVI] LE Credential created and granted"
     echo
 }
 
+function create_and_grant_le_credential() {
+    create_le_credential || return 1
+    grant_le_credential || return 1
+    load_qvi_issuance_result le
+}
+
 # LE: Admit LE credential from QVI
+wait_for_kli_ipex_grant_said() {
+    local name=$1
+    local alias=$2
+    local passcode=$3
+    local deadline=$((SECONDS + WORKFLOW_TIMEOUT_SECONDS))
+    local grant_said=""
+
+    while [[ "${SECONDS}" -lt "${deadline}" ]]; do
+        grant_said=$(kli ipex list \
+            --name "${name}" \
+            --alias "${alias}" \
+            --passcode "${passcode}" \
+            --type grant \
+            --poll \
+            --said |
+            sort -u |
+            tail -n 1 |
+            tr -d '[:space:]') || return 1
+        if [[ -n "${grant_said}" ]]; then
+            printf '%s\n' "${grant_said}"
+            return 0
+        fi
+        sleep 1
+    done
+
+    print_red "Timed out waiting for an IPEX grant for ${name}/${alias}"
+    return 124
+}
+
 function admit_le_credential() {
     print_dark_gray "Listing IPEX Grants for LAR 1"
-    SAID=$(kli ipex list \
-        --name "${LAR1}" \
-        --alias "${LE_NAME}" \
-        --passcode "${LAR1_PASSCODE}" \
-        --type "grant" \
-        --poll \
-        --said | uniq | tr -d '[:space:]') # there are three grant messages, one from each QAR, yet all share the same SAID, so uniq condenses them to one
+    SAID=$(wait_for_kli_ipex_grant_said \
+        "${LAR1}" "${LE_NAME}" "${LAR1_PASSCODE}") || return 1
 
     print_dark_gray "Listing IPEX Grants for LAR 2"
     # prime the mailbox to properly receive the messages.
@@ -1638,7 +1873,7 @@ function admit_le_credential() {
         --passcode "${LAR2_PASSCODE}" \
         --type "grant" \
         --poll \
-        --said | uniq
+        --said >/dev/null || return 1
 
     echo
     print_yellow "[LE] Admitting LE Credential ${SAID} to ${LE_NAME} as ${LAR1}"
@@ -1657,7 +1892,7 @@ function admit_le_credential() {
         --passcode "${LAR2_PASSCODE}" \
         --auto
 
-    wait_kli_jobs lar1 lar2
+    wait_kli_jobs lar1 lar2 || return 1
 
     echo
     print_green "[LE] Admitted LE credential"
@@ -1829,13 +2064,9 @@ function grant_oor_auth_credential() {
 
 # QVI: Admit OOR Auth credential
 function admit_oor_auth_credential() {
-    OOR_AUTH_SAID=$(kli vc list \
-        --name "${LAR2}" \
-        --alias "${LE_NAME}" \
-        --passcode "${LAR2_PASSCODE}" \
-        --issued \
-        --said \
-        --schema ${OOR_AUTH_SCHEMA} | tr -d '[:space:]')
+    if [[ -z "${OOR_AUTH_SAID:-}" ]]; then
+        load_oor_auth_credential_said || return 1
+    fi
     echo
     print_yellow "[QVI] Admitting OOR Auth Credential ${OOR_AUTH_SAID} from LE"
     admit_qvi_received_credential \
@@ -1849,17 +2080,27 @@ function admit_oor_auth_credential() {
     echo
 }
 
+load_oor_auth_credential_said() {
+    OOR_AUTH_SAID=$(kli vc list \
+        --name "${LAR2}" \
+        --alias "${LE_NAME}" \
+        --passcode "${LAR2_PASSCODE}" \
+        --issued \
+        --said \
+        --schema "${OOR_AUTH_SCHEMA}" |
+        tail -1 |
+        tr -d '[:space:]')
+    [[ -n "${OOR_AUTH_SAID}" ]]
+    export OOR_AUTH_SAID
+}
+
 ########################### OOR Credential ##############################
 # 24. QVI: Issue, grant OOR to Person and Person admits OOR
 # Prepare OOR Auth edge data
 function prepare_oor_auth_edge() {
-    OOR_AUTH_SAID=$(kli vc list \
-        --name ${LAR1} \
-        --alias ${LE_NAME} \
-        --passcode "${LAR1_PASSCODE}" \
-        --issued \
-        --said \
-        --schema ${OOR_AUTH_SCHEMA} | tr -d '[:space:]')
+    if [[ -z "${OOR_AUTH_SAID:-}" ]]; then
+        load_oor_auth_credential_said || return 1
+    fi
     print_bg_blue "[QVI] Preparing [OOR Auth] edge with [OOR Auth] Credential SAID: ${OOR_AUTH_SAID}"
     jq -n \
         --arg credentialSaid "${OOR_AUTH_SAID}" \
@@ -1884,7 +2125,7 @@ function prepare_oor_cred_data() {
 }
 
 # Create OOR credential in QVI, issued to the Person
-function create_and_grant_oor_credential() {
+function create_oor_credential() {
     local credential_creation_failed=false
     local issuance_result=""
 
@@ -1895,7 +2136,7 @@ function create_and_grant_oor_credential() {
     print_lcyan "$(cat "${KLI_DATA_DIR}/temp-data/oor-data.json")"
 
     echo
-    print_green "[QVI] creating and granting OOR credential"
+    print_green "[QVI] creating OOR credential"
 
     issuance_result=$(run_qvi_json \
       ms-issue \
@@ -1904,8 +2145,9 @@ function create_and_grant_oor_credential() {
       --issuee-prefix "${PERSON_PRE}") ||
       credential_creation_failed=true
     if [[ "${credential_creation_failed}" == true ]]; then
-        fail_workflow "[QVI] Failed to create and grant the OOR credential"
+        fail_workflow "[QVI] Failed to create the OOR credential"
     fi
+    store_qvi_issuance_result oor "${issuance_result}"
     record_qvi_issuance_result "${issuance_result}"
     OOR_CRED_SAID="${LAST_ISSUED_CREDENTIAL_SAID}"
     assert_qvi_credential_state \
@@ -1914,10 +2156,23 @@ function create_and_grant_oor_credential() {
         "${OOR_SCHEMA}" \
         "${PERSON_PRE}" \
         0
+}
+
+function grant_oor_credential() {
+    run_qvi_json \
+        ms-grant \
+        --credential-said "${OOR_CRED_SAID}" \
+        --recipient-prefix "${PERSON_PRE}" >/dev/null ||
+        fail_workflow "[QVI] Failed to grant the OOR credential"
 
     echo
-    print_lcyan "[QVI] OOR credential created"
+    print_lcyan "[QVI] OOR credential created and granted"
     echo
+}
+
+function create_and_grant_oor_credential() {
+    create_oor_credential || return 1
+    grant_oor_credential
 }
 
 admit_person_leaf_credential() {
@@ -2018,7 +2273,49 @@ function revoke_ecr_credential() {
     revoke_qvi_leaf_credential "ECR" "${ECR_CRED_SAID}" "${ECR_SCHEMA}"
 }
 
-function present_revoked_oor_to_sally() {
+person_observes_revoked_oor() {
+    assert_person_credential_state \
+        "${OOR_CRED_SAID}" \
+        "${QVI_PRE}" \
+        "${OOR_SCHEMA}" \
+        "${PERSON_PRE}" \
+        1 >/dev/null 2>&1
+}
+
+refresh_person_revoked_oor_state() {
+    local refresh_failed=false
+
+    # The issuer has the authoritative revocation TEL. Re-present the
+    # credential to its holder, then require the Person wallet to observe
+    # status 1 before it reports to Sally.
+    run_qvi_json \
+        ms-present \
+        --actor qvi \
+        --credential-said "${OOR_CRED_SAID}" \
+        --recipient-prefix "${PERSON_PRE}" >/dev/null ||
+        refresh_failed=true
+    if [[ "${refresh_failed}" == true ]]; then
+        fail_workflow "[PERSON] Failed to receive the revoked OOR state from QVI"
+    fi
+
+    poll_until \
+        "Person observation of revoked OOR ${OOR_CRED_SAID}" \
+        "${WORKFLOW_TIMEOUT_SECONDS}" \
+        person_observes_revoked_oor >/dev/null ||
+        refresh_failed=true
+    if [[ "${refresh_failed}" == true ]]; then
+        fail_workflow "[PERSON] Failed to observe the revoked OOR state"
+    fi
+
+    assert_person_credential_state \
+        "${OOR_CRED_SAID}" \
+        "${QVI_PRE}" \
+        "${OOR_SCHEMA}" \
+        "${PERSON_PRE}" \
+        1
+}
+
+transmit_revoked_oor_to_sally() {
     local credential_said_is_missing=false
     [[ -z "${OOR_CRED_SAID}" ]] && credential_said_is_missing=true
     if [[ "${credential_said_is_missing}" == true ]]; then
@@ -2029,16 +2326,18 @@ function present_revoked_oor_to_sally() {
     local presentation_boundary
     local evidence_wait_failed=false
 
+    person_observes_revoked_oor ||
+        fail_workflow "[PERSON] Cannot present OOR before observing its revoked state"
     presentation_boundary=$(utc_now)
-    print_yellow "[QVI] Presenting revoked OOR credential ${OOR_CRED_SAID} to Sally"
+    print_yellow "[PERSON] Presenting revoked OOR credential ${OOR_CRED_SAID} to Sally"
     run_qvi_json \
         ms-present \
-        --actor qvi \
+        --actor person \
         --credential-said "${OOR_CRED_SAID}" \
         --recipient-prefix "${DIRECT_SALLY_PRE}" >/dev/null ||
         credential_transmission_failed=true
     if [[ "${credential_transmission_failed}" == true ]]; then
-        fail_workflow "[QVI] Failed to transmit revoked OOR credential ${OOR_CRED_SAID}"
+        fail_workflow "[PERSON] Failed to transmit revoked OOR credential ${OOR_CRED_SAID}"
     fi
 
     # revoked_oor_was_rejected_and_reported checks the callback file and one
@@ -2051,9 +2350,14 @@ function present_revoked_oor_to_sally() {
         "${presentation_boundary}" \
         "${OOR_CRED_SAID}" >/dev/null || evidence_wait_failed=true
     if [[ "${evidence_wait_failed}" == true ]]; then
-        fail_workflow "[QVI] Sally did not prove revoked-OOR rejection and reporting for ${OOR_CRED_SAID}"
+        fail_workflow "[PERSON] Sally did not prove revoked-OOR rejection and reporting for ${OOR_CRED_SAID}"
     fi
-    print_green "[QVI] Sally rejected revoked OOR ${OOR_CRED_SAID} and emitted the exact revocation callback"
+    print_green "[PERSON] Sally rejected revoked OOR ${OOR_CRED_SAID} and emitted the exact revocation callback"
+}
+
+function present_revoked_oor_to_sally() {
+    refresh_person_revoked_oor_state || return 1
+    transmit_revoked_oor_to_sally
 }
 
 ############################ ECR Auth ##################################
@@ -2158,13 +2462,9 @@ function grant_ecr_auth_credential() {
 
 # Admit ECR Auth credential from LE
 function admit_ecr_auth_credential() {
-    ECR_AUTH_SAID=$(kli vc list \
-        --name "${LAR2}" \
-        --alias "${LE_NAME}" \
-        --passcode "${LAR2_PASSCODE}" \
-        --issued \
-        --said \
-        --schema ${ECR_AUTH_SCHEMA} | tr -d '[:space:]')
+    if [[ -z "${ECR_AUTH_SAID:-}" ]]; then
+        load_ecr_auth_credential_said || return 1
+    fi
     echo
     print_yellow "[QVI] Admitting ECR Auth Credential ${ECR_AUTH_SAID} from LE"
     admit_qvi_received_credential \
@@ -2178,17 +2478,27 @@ function admit_ecr_auth_credential() {
     echo
 }
 
+load_ecr_auth_credential_said() {
+    ECR_AUTH_SAID=$(kli vc list \
+        --name "${LAR2}" \
+        --alias "${LE_NAME}" \
+        --passcode "${LAR2_PASSCODE}" \
+        --issued \
+        --said \
+        --schema "${ECR_AUTH_SCHEMA}" |
+        tail -1 |
+        tr -d '[:space:]')
+    [[ -n "${ECR_AUTH_SAID}" ]]
+    export ECR_AUTH_SAID
+}
+
 ############################ ECR ##################################
 # 23 Create and Issue ECR credential to Person
 # Prepare ECR Auth edge data
 function prepare_ecr_auth_edge() {
-    ECR_AUTH_SAID=$(kli vc list \
-        --name ${LAR1} \
-        --alias ${LE_NAME} \
-        --passcode "${LAR1_PASSCODE}" \
-        --issued \
-        --said \
-        --schema ${ECR_AUTH_SCHEMA} | tr -d '[:space:]')
+    if [[ -z "${ECR_AUTH_SAID:-}" ]]; then
+        load_ecr_auth_credential_said || return 1
+    fi
     print_bg_blue "[QVI] Preparing [ECR Auth] edge with [ECR Auth] Credential SAID: ${ECR_AUTH_SAID}"
     jq -n \
         --arg credentialSaid "${ECR_AUTH_SAID}" \
@@ -2213,7 +2523,7 @@ function prepare_ecr_cred_data() {
 }
 
 # QVI Grant ECR credential to PERSON
-function create_and_grant_ecr_credential() {
+function create_ecr_credential() {
     local credential_creation_failed=false
     local issuance_result=""
 
@@ -2223,8 +2533,7 @@ function create_and_grant_ecr_credential() {
     print_lcyan "[QVI] ECR Credential Data"
     print_lcyan "$(cat "${KLI_DATA_DIR}/temp-data/ecr-data.json")"
 
-    pause "Press [enter] to create and grant the ECR credential"
-    print_green "[QVI] creating and granting ECR credential"
+    print_green "[QVI] creating ECR credential"
 
     issuance_result=$(run_qvi_json \
       ms-issue \
@@ -2233,8 +2542,9 @@ function create_and_grant_ecr_credential() {
       --issuee-prefix "${PERSON_PRE}") ||
       credential_creation_failed=true
     if [[ "${credential_creation_failed}" == true ]]; then
-        fail_workflow "[QVI] Failed to create and grant the ECR credential"
+        fail_workflow "[QVI] Failed to create the ECR credential"
     fi
+    store_qvi_issuance_result ecr "${issuance_result}"
     record_qvi_issuance_result "${issuance_result}"
     ECR_CRED_SAID="${LAST_ISSUED_CREDENTIAL_SAID}"
     assert_qvi_credential_state \
@@ -2243,10 +2553,23 @@ function create_and_grant_ecr_credential() {
         "${ECR_SCHEMA}" \
         "${PERSON_PRE}" \
         0
+}
+
+function grant_ecr_credential() {
+    run_qvi_json \
+        ms-grant \
+        --credential-said "${ECR_CRED_SAID}" \
+        --recipient-prefix "${PERSON_PRE}" >/dev/null ||
+        fail_workflow "[QVI] Failed to grant the ECR credential"
 
     echo
     print_lcyan "[QVI] ECR credential created and granted"
     echo
+}
+
+function create_and_grant_ecr_credential() {
+    create_ecr_credential || return 1
+    grant_ecr_credential
 }
 
 # Person: Admit ECR credential from QVI
@@ -2326,21 +2649,82 @@ function setup() {
   create_docker_containers || return 1
   start_foundation_services || return 1
   preflight_versions || return 1
-  setup_keria_identifiers || return 1
-  create_aids || return 1
-  read_prefixes || return 1
-  resolve_gar_oobis || return 1
+  setup_participant_identifiers_parallel || return 1
+  resolve_foundational_member_oobis || return 1
+}
+
+load_foundational_group_prefixes() {
+  GEDA_PRE=$(kli status \
+      --name "${GAR1}" \
+      --alias "${GEDA_NAME}" \
+      --passcode "${GAR1_PASSCODE}" |
+      awk '/Identifier:/ {print $2}' |
+      tr -d '[:space:]')
+  LE_PRE=$(kli status \
+      --name "${LAR1}" \
+      --alias "${LE_NAME}" \
+      --passcode "${LAR1_PASSCODE}" |
+      awk '/Identifier:/ {print $2}' |
+      tr -d '[:space:]')
+  [[ -n "${GEDA_PRE}" && -n "${LE_PRE}" ]] || return 1
+  export GEDA_PRE LE_PRE
+}
+
+create_foundational_multisigs_parallel() {
+  start_workflow_job \
+      create-geda gar1,gar2 create_geda_multisig || return 1
+  start_workflow_job \
+      create-le lar1,lar2 create_le_multisig || return 1
+  wait_for_background_jobs create-geda create-le || return 1
+  load_foundational_group_prefixes
+}
+
+capture_foundational_group_oobis() {
+  GEDA_OOBI=$(kli oobi generate \
+      --name "${GAR1}" \
+      --passcode "${GAR1_PASSCODE}" \
+      --alias "${GEDA_NAME}" \
+      --role witness) || return 1
+  LE_OOBI=$(kli oobi generate \
+      --name "${LAR1}" \
+      --passcode "${LAR1_PASSCODE}" \
+      --alias "${LE_NAME}" \
+      --role witness) || return 1
+  [[ -n "${GEDA_OOBI}" && -n "${LE_OOBI}" ]]
+}
+
+qars_resolve_foundational_oobis() {
+  qars_resolve_geda_oobi || return 1
+  qars_resolve_le_oobi
+}
+
+create_foundational_state_parallel() {
+  start_workflow_job \
+      create-geda-registry gar1,gar2 create_geda_reg || return 1
+  start_workflow_job \
+      create-le-registry lar1,lar2 create_le_reg || return 1
+  start_workflow_job \
+      start-direct-sally direct-sally start_sally || return 1
+  start_workflow_job \
+      resolve-foundation-qars qar1,qar2,qar3,qar4,person \
+      qars_resolve_foundational_oobis || return 1
+  wait_for_background_jobs \
+      create-geda-registry \
+      create-le-registry \
+      start-direct-sally \
+      resolve-foundation-qars || return 1
+  load_sally_prefixes
 }
 
 # Sets up GEDA, GEDA registry, delegation to the QVI, and QVI OOBI resolution for GARs and LARs
 function geda_delegation_to_qvi() {
-  create_geda_multisig || return 1
-  create_geda_reg || return 1
-  start_sally || return 1
+  create_foundational_multisigs_parallel || return 1
+  capture_foundational_group_oobis || return 1
+  create_foundational_state_parallel || return 1
   resolve_oobis || return 1
   challenge_response || return 1
-  qars_resolve_geda_oobi || return 1
   establish_qvi || return 1
+  create_qvi_reg || return 1
 }
 
 # Creates the QVI credential, grants it from the GEDA to the QVI, and presents it to sally
@@ -2355,14 +2739,10 @@ function qvi_credential() {
 
 # Creates the LE multisig, resolves the LE OOBI, creates the QVI registry, and prepares and grants the LE credential
 function le_creation_and_granting() {
-  create_le_multisig || return 1
-  qars_resolve_le_oobi || return 1
-  create_qvi_reg || return 1
   prepare_qvi_edge || return 1
   prepare_le_cred_data || return 1
   create_and_grant_le_credential || return 1
   admit_le_credential || return 1
-  create_le_reg || return 1
   prepare_le_edge || return 1
 }
 
@@ -2376,6 +2756,7 @@ function oor_auth_cred() {
   prepare_oor_auth_data || return 1
   create_oor_auth_credential || return 1
   grant_oor_auth_credential || return 1
+  load_oor_auth_credential_said || return 1
   admit_oor_auth_credential || return 1
   prepare_oor_auth_edge || return 1
 }
@@ -2398,6 +2779,7 @@ function ecr_auth_cred() {
   prepare_ecr_auth_data || return 1
   create_ecr_auth_credential || return 1
   grant_ecr_auth_credential || return 1
+  load_ecr_auth_credential_said || return 1
   admit_ecr_auth_credential || return 1
   prepare_ecr_auth_edge || return 1
 }
@@ -2415,6 +2797,70 @@ function ecr_auth_and_ecr_cred() {
   ecr_cred || return 1
 }
 
+issue_and_grant_oor_auth_credential() {
+  create_oor_auth_credential || return 1
+  grant_oor_auth_credential
+}
+
+issue_and_grant_ecr_auth_credential() {
+  create_ecr_auth_credential || return 1
+  grant_ecr_auth_credential
+}
+
+optimized_leaf_credential_pipeline() {
+  prepare_oor_auth_data || return 1
+  prepare_ecr_auth_data || return 1
+
+  issue_and_grant_oor_auth_credential || return 1
+  load_oor_auth_credential_said || return 1
+
+  start_workflow_job \
+      admit-oor-auth qvi admit_oor_auth_credential || return 1
+  start_workflow_job \
+      issue-ecr-auth lar1,lar2 \
+      issue_and_grant_ecr_auth_credential || return 1
+  wait_for_background_jobs admit-oor-auth issue-ecr-auth || return 1
+  load_ecr_auth_credential_said || return 1
+
+  prepare_oor_auth_edge || return 1
+  prepare_ecr_auth_edge || return 1
+  prepare_oor_cred_data || return 1
+  prepare_ecr_cred_data || return 1
+
+  create_and_grant_oor_credential || return 1
+  start_workflow_job \
+      admit-oor person admit_oor_credential || return 1
+  start_workflow_job \
+      admit-ecr-auth qvi admit_ecr_auth_credential || return 1
+  wait_for_background_jobs admit-oor admit-ecr-auth || return 1
+
+  pause "Press [ENTER] to present OOR to Sally" || return 1
+  start_workflow_job \
+      present-active-oor person,direct-sally \
+      person_present_oor_cred_to_sally || return 1
+  start_workflow_job \
+      issue-ecr qvi create_ecr_credential || return 1
+  wait_for_background_jobs present-active-oor issue-ecr || return 1
+  load_qvi_issuance_result ecr || return 1
+
+  grant_ecr_credential || return 1
+  start_workflow_job \
+      admit-ecr person admit_ecr_credential || return 1
+  start_workflow_job \
+      revoke-oor qvi revoke_oor_credential || return 1
+  wait_for_background_jobs admit-ecr revoke-oor || return 1
+
+  # Refresh the holder before the final wave. The refresh is a QVI mutation,
+  # so it must finish before ECR revocation starts on the same group.
+  refresh_person_revoked_oor_state || return 1
+  start_workflow_job \
+      present-revoked-oor person,direct-sally \
+      transmit_revoked_oor_to_sally || return 1
+  start_workflow_job \
+      revoke-ecr qvi revoke_ecr_credential || return 1
+  wait_for_background_jobs present-revoked-oor revoke-ecr
+}
+
 # Exit successfully after the requested top-level workflow phase. The EXIT
 # trap owns cleanup and honors --keep-runtime.
 stop_after() {
@@ -2425,6 +2871,7 @@ stop_after() {
   fi
 
   print_lcyan "Stopped after ${completed_phase} as requested"
+  print_workflow_timing_summary
   exit 0
 }
 
@@ -2433,37 +2880,58 @@ function main_flow() {
   print_lcyan "--------------------------------------------------------------------------------"
   print_lcyan "                       Running canonical QVI workflow"
   print_lcyan "--------------------------------------------------------------------------------"
-  setup || return 1
+  run_workflow_phase setup setup || return 1
   stop_after setup
-  geda_delegation_to_qvi || return 1
+  run_workflow_phase \
+      geda_delegation_to_qvi geda_delegation_to_qvi || return 1
   stop_after geda_delegation_to_qvi
-  qvi_credential || return 1
+  run_workflow_phase qvi_credential qvi_credential || return 1
   stop_after qvi_credential
 
-  le_creation_and_granting || return 1
+  run_workflow_phase \
+      le_creation_and_granting le_creation_and_granting || return 1
   stop_after le_creation_and_granting
   pause "Press [ENTER] to present LE credential to Sally" || return 1
-  le_sally_presentation || return 1
+  run_workflow_phase \
+      le_sally_presentation le_sally_presentation || return 1
   stop_after le_sally_presentation
 
-  oor_auth_and_oor_cred || return 1
+  if [[ -z "${WORKFLOW_STOP_AFTER}" ]]; then
+    run_workflow_phase \
+        leaf_credential_pipeline \
+        optimized_leaf_credential_pipeline || return 1
+    pause "Press [enter] to end workflow" || return 1
+    run_workflow_phase end_workflow end_workflow || return 1
+    return 0
+  fi
+
+  # Keep the fine-grained --stop-after checkpoints serial and observable.
+  run_workflow_phase \
+      oor_auth_and_oor_cred oor_auth_and_oor_cred || return 1
   stop_after oor_auth_and_oor_cred
   pause "Press [ENTER] to present OOR to Sally" || return 1
-  person_present_oor_cred_to_sally || return 1
+  run_workflow_phase \
+      person_present_oor_cred_to_sally \
+      person_present_oor_cred_to_sally || return 1
   stop_after person_present_oor_cred_to_sally
 
-  revoke_oor_credential || return 1
+  run_workflow_phase \
+      revoke_oor_credential revoke_oor_credential || return 1
   stop_after revoke_oor_credential
-  present_revoked_oor_to_sally || return 1
+  run_workflow_phase \
+      present_revoked_oor_to_sally \
+      present_revoked_oor_to_sally || return 1
   stop_after present_revoked_oor_to_sally
 
-  ecr_auth_and_ecr_cred || return 1
+  run_workflow_phase \
+      ecr_auth_and_ecr_cred ecr_auth_and_ecr_cred || return 1
   stop_after ecr_auth_and_ecr_cred
-  revoke_ecr_credential || return 1
+  run_workflow_phase \
+      revoke_ecr_credential revoke_ecr_credential || return 1
   stop_after revoke_ecr_credential
 
   pause "Press [enter] to end workflow" || return 1
-  end_workflow || return 1
+  run_workflow_phase end_workflow end_workflow || return 1
   stop_after end_workflow
 }
 
@@ -2712,6 +3180,7 @@ main() {
 
     workflow_duration=$(( $(date +%s) - START_TIME ))
     print_lcyan "Full chain workflow completed in ${workflow_duration} seconds"
+    print_workflow_timing_summary
 }
 
 script_is_being_executed=false

--- a/qvi-workflow/sig_ts_wallets/src/sig-wallet.ts
+++ b/qvi-workflow/sig_ts_wallets/src/sig-wallet.ts
@@ -955,21 +955,31 @@ async function synchronizeMembersAction(
     const wallets = await loadWallets(config, allRoles);
     const observers = selectWallets(wallets, observerRoles);
     const subjects = selectWallets(wallets, subjectRoles);
-    let queryCount = 0;
-    for (const observer of observers) {
-        for (const subject of subjects) {
-            if (observer.aid.prefix === subject.aid.prefix) {
-                continue;
+    const queryCounts = await Promise.all(
+        observers.map(async (observer) => {
+            let observerQueryCount = 0;
+            // One observer wallet remains a serial mutation lane. Distinct
+            // observers can safely refresh their independent local stores at
+            // the same time.
+            for (const subject of subjects) {
+                if (observer.aid.prefix === subject.aid.prefix) {
+                    continue;
+                }
+                await waitOperation(
+                    observer.client,
+                    await observer.client
+                        .keyStates()
+                        .query(subject.aid.prefix, subject.aid.state.s)
+                );
+                observerQueryCount += 1;
             }
-            await waitOperation(
-                observer.client,
-                await observer.client
-                    .keyStates()
-                    .query(subject.aid.prefix, subject.aid.state.s)
-            );
-            queryCount += 1;
-        }
-    }
+            return observerQueryCount;
+        })
+    );
+    const queryCount = queryCounts.reduce(
+        (total, count) => total + count,
+        0
+    );
     return {status: 'synchronized', queryCount};
 }
 
@@ -1483,7 +1493,7 @@ async function assertKnownQviCredential(
     );
 }
 
-/** Issue, assert, and then grant one workflow-selected credential. */
+/** Issue and assert one workflow-selected credential without granting it. */
 async function issueAction(
     config: WorkflowConfig,
     args: Record<string, string>
@@ -1524,18 +1534,37 @@ async function issueAction(
         credentialSaid,
         '0'
     );
-    await grantCredential({
-        members,
-        initiatorPrefix: initiator.memberAid.prefix,
-        recipientPrefix: args['issuee-prefix'],
-        credentials,
-        timestamp: createTimestamp(),
-    });
     return {
         status: 'issued',
         credentialSaid: snapshot.said,
         registryId: snapshot.registry,
         telDigest: snapshot.currentTelDigest,
+    };
+}
+
+/** Grant one already-issued credential to its explicit recipient. */
+async function grantAction(
+    config: WorkflowConfig,
+    args: Record<string, string>
+) {
+    const members = await loadFinalQviMembers(config);
+    const initiator = firstGroupMember(members);
+    const credentials = await Promise.all(
+        members.map(({client}) =>
+            getCredential(client, args['credential-said'])
+        )
+    );
+    await grantCredential({
+        members,
+        initiatorPrefix: initiator.memberAid.prefix,
+        recipientPrefix: args['recipient-prefix'],
+        credentials,
+        timestamp: createTimestamp(),
+    });
+    return {
+        status: 'granted',
+        credentialSaid: args['credential-said'],
+        recipientPrefix: args['recipient-prefix'],
     };
 }
 
@@ -1914,6 +1943,18 @@ export async function run(
                 'issuee-prefix'
             );
             return await issueAction(
+                readWorkflowConfig(args.config),
+                args
+            );
+        }
+        case 'ms-grant': {
+            args = parseExactArguments(
+                values,
+                'config',
+                'credential-said',
+                'recipient-prefix'
+            );
+            return await grantAction(
                 readWorkflowConfig(args.config),
                 args
             );

--- a/qvi-workflow/sig_ts_wallets/test/sig-wallet-entrypoint.test.ts
+++ b/qvi-workflow/sig_ts_wallets/test/sig-wallet-entrypoint.test.ts
@@ -52,6 +52,34 @@ describe('Signify wallet entrypoint boundary', () => {
         );
     });
 
+    it('keeps credential issuance and grant as separate CLI actions', async () => {
+        await assert.rejects(
+            run([
+                'ms-grant',
+                '--config',
+                '/missing/workflow.json',
+                '--credential-said',
+                'E-credential',
+                '--recipient-prefix',
+                'E-recipient',
+            ]),
+            (error: unknown) =>
+                error instanceof Error &&
+                !(error instanceof UsageError) &&
+                error.message.includes('/missing/workflow.json')
+        );
+        await assert.rejects(
+            run([
+                'ms-grant',
+                '--config',
+                'workflow.json',
+                '--credential-said',
+                'E-credential',
+            ]),
+            UsageError
+        );
+    });
+
     it('accepts only credential-free HTTP(S) URLs', () => {
         assert.equal(
             requireHttpUrl('http://keria1:3901/', 'admin'),


### PR DESCRIPTION
## Summary

- add resource-aware background jobs with group deadlines, fail-fast cancellation, per-job logs/results, and JSONL timing output
- keep KLI and Signify runners alive and execute commands in the existing containers
- restore the full challenge matrix, QAR4 replacement rotation, direct Sally callbacks, leaf revocation, and split issue/grant operations
- overlap only actor-disjoint setup, observation, approval, credential, and revocation work

## Performance

- serial baseline median: 828 seconds across three clean runs
- first complete optimized proof: 606 seconds, a 26.8% reduction
- hardened setup through final QVI convergence: 307 seconds, 74 seconds faster than the earlier optimized section

See qvi-workflow/keria_docker/BENCHMARK.md for the measurement boundary and hardware details.

## Verification

- Bash syntax and workflow runtime contract tests
- TypeScript typecheck and 53 tests
- callback recorder tests
- Compose rendering and git diff checks
- clean complete E2E proof with all 16 challenge exchanges, QVI sequences 0-3, six credential operations, active callbacks, revoked OOR rejection, and rev callback